### PR TITLE
fix: 입찰 이력이 없을 때 입찰 가능 횟수가 0으로 표시되는 문제 수정

### DIFF
--- a/src/main/java/org/chzz/market/common/config/RedisConfig.java
+++ b/src/main/java/org/chzz/market/common/config/RedisConfig.java
@@ -2,6 +2,8 @@ package org.chzz.market.common.config;
 
 import org.chzz.market.domain.notification.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -15,6 +17,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableAutoConfiguration(exclude = RedisAutoConfiguration.class)
 public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -17,6 +17,7 @@ import org.chzz.market.domain.auction.service.AuctionRegistrationServiceFactory;
 import org.chzz.market.domain.auction.service.AuctionService;
 import org.chzz.market.domain.auction.service.register.AuctionRegistrationService;
 import org.chzz.market.domain.auction.type.AuctionViewType;
+import org.chzz.market.domain.auction.type.TestService;
 import org.chzz.market.domain.bid.service.BidService;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.springframework.data.domain.Page;
@@ -42,6 +43,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AuctionController {
     private final AuctionService auctionService;
     private final BidService bidService;
+    private final TestService testService;
     private final AuctionRegistrationServiceFactory registrationServiceFactory;
 
     /**
@@ -165,5 +167,17 @@ public class AuctionController {
         StartAuctionResponse response = auctionService.startAuction(userId, request);
         log.info("경매 상품으로 성공적으로 전환되었습니다. 상품 ID: {}", response.productId());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+//    ---------------------------------------------------------------------------------------
+
+    /**
+     * 경매 종료 테스트 API (삭제 필요)
+     */
+    @PostMapping("/test")
+    public ResponseEntity<?> testEndAuction(@LoginUser Long userId,
+                                            @RequestParam("minutes") int minutes) {
+        testService.test(userId, minutes);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -150,7 +150,7 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                         bid.id.isNotNull(),
                         bid.id,
                         bid.amount.coalesce(0L),
-                        bid.count.coalesce(0)
+                        bid.count.coalesce(3)
                 ))
                 .from(auction)
                 .join(auction.product, product)

--- a/src/main/java/org/chzz/market/domain/auction/type/TestService.java
+++ b/src/main/java/org/chzz/market/domain/auction/type/TestService.java
@@ -1,0 +1,62 @@
+package org.chzz.market.domain.auction.type;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.chzz.market.domain.auction.entity.Auction;
+import org.chzz.market.domain.auction.repository.AuctionRepository;
+import org.chzz.market.domain.image.entity.Image;
+import org.chzz.market.domain.image.repository.ImageRepository;
+import org.chzz.market.domain.product.entity.Product;
+import org.chzz.market.domain.product.entity.Product.Category;
+import org.chzz.market.domain.product.repository.ProductRepository;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * 경매종료 테스트 서비스 삭제필요
+ */
+@Service
+@RequiredArgsConstructor
+public class TestService {
+    private final AuctionRepository auctionRepository;
+    private final ProductRepository productRepository;
+    private final ImageRepository imageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void test(Long userId, int minutes) {
+        Random random = new Random();
+        int randomIndex = random.nextInt(1000) + 1;  // 1부터 1000까지 랜덤 숫자 생성
+        int randomIndex1 = random.nextInt(1000) + 1;  // 1부터 1000까지 랜덤 숫자 생성
+        User user = userRepository.findById(userId).get();
+        Product product = Product.builder()
+                .name("테스트" + randomIndex)
+                .description("test")
+                .category(Category.ELECTRONICS)
+                .user(user)
+                .minPrice(10000)
+                .build();
+        productRepository.save(product);
+
+        Image image1 = Image.builder()
+                .cdnPath("https://picsum.photos/id/" + randomIndex + "/200/200")
+                .product(product)
+                .build();
+        Image image2 = Image.builder()
+                .cdnPath("https://picsum.photos/id/" + randomIndex1 + "/200/200")
+                .product(product)
+                .build();
+        imageRepository.save(image1);
+        imageRepository.save(image2);
+        product.addImages(List.of(image1, image2));
+        auctionRepository.save(Auction.builder()
+                .status(AuctionStatus.PROCEEDING)
+                .endDateTime(LocalDateTime.now().plusMinutes(minutes))
+                .product(product)
+                .build());
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -25,6 +25,8 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      repositories:
+        enabled: false
 
   security:
     oauth2:

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -214,6 +214,7 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.get().getBidAmount()).isEqualTo(0);
         assertThat(result.get().getIsParticipated()).isFalse();
         assertThat(result.get().getBidId()).isNull();
+        assertThat(result.get().getRemainingBidCount()).isEqualTo(3);
     }
 
     @Test
@@ -233,6 +234,7 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.get().getBidAmount()).isEqualTo(6000L);
         assertThat(result.get().getIsParticipated()).isTrue();
         assertThat(result.get().getBidId()).isEqualTo(bid4.getId());
+        assertThat(result.get().getRemainingBidCount()).isEqualTo(2);
     }
 
     @Test
@@ -247,6 +249,26 @@ class AuctionRepositoryCustomImplTest {
 
         //then
         assertThat(result).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("경매 상세 조회 - 비로그인 상태에서 조회 할 경우")
+    public void testAuctionDetailsWhenUserIdIsNull() throws Exception {
+        //given
+        Long auctionId = auction2.getId();
+        Long userId = null;
+
+        //when
+        Optional<AuctionDetailsResponse> result = auctionRepository.findAuctionDetailsById(auctionId, userId);
+
+        //then
+        assertThat(result).isPresent();
+        assertThat(result.get().getProductId()).isEqualTo(product2.getId());
+        assertThat(result.get().getIsSeller()).isFalse();
+        assertThat(result.get().getBidAmount()).isEqualTo(0L);
+        assertThat(result.get().getIsParticipated()).isFalse();
+        assertThat(result.get().getBidId()).isNull();
+        assertThat(result.get().getRemainingBidCount()).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-118]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 로그인 한 상태에서 입찰 이력이 없을 때 입찰 가능 횟수가 0으로 표시되는 문제를 수정하였습니다.
- 이를 입찰 한적이 없거나 비로그인 유저인 경우 0이 아닌 3으로 수정하였습니다.
- 경매종료 임시테스트 api를 기존 파일에 최대한 영향없게 새롭게 클래스하나 만들었으니 추후에 삭제하면 될것같습니다

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

![스크린샷 2024-10-03 오전 3 36 14](https://github.com/user-attachments/assets/d063a2c0-26d5-4747-9948-35e76c2b3e93)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->


[CHZZ-118]: https://chzz-market.atlassian.net/browse/CHZZ-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ