### PR TITLE
refactor: 사전 등록 상품 이미지 수정 로직 변경

### DIFF
--- a/src/main/java/org/chzz/market/domain/image/dto/ImageResponse.java
+++ b/src/main/java/org/chzz/market/domain/image/dto/ImageResponse.java
@@ -1,0 +1,18 @@
+package org.chzz.market.domain.image.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import org.chzz.market.domain.image.entity.Image;
+
+public record ImageResponse(
+        Long imageId,
+        String imageUrl
+) {
+
+    @QueryProjection
+    public ImageResponse {
+    }
+
+    public static ImageResponse from(Image image) {
+        return new ImageResponse(image.getId(), image.getCdnPath());
+    }
+}

--- a/src/main/java/org/chzz/market/domain/product/dto/ProductDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/ProductDetailsResponse.java
@@ -16,7 +16,7 @@ public class ProductDetailsResponse {
     private final String productName;
     private final String sellerNickname;
     private final Integer minPrice;
-    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
     private final String description;
     private final Long likeCount;
     private final Boolean isLiked;
@@ -26,13 +26,13 @@ public class ProductDetailsResponse {
 
     @QueryProjection
     public ProductDetailsResponse(Long productId, String productName, String sellerNickname,
-                                  Integer minPrice, LocalDateTime createdAt, String description,
+                                  Integer minPrice, LocalDateTime updatedAt, String description,
                                   Long likeCount, Boolean isLiked, Boolean isSeller, Category category) {
         this.productId = productId;
         this.productName = productName;
         this.sellerNickname = sellerNickname;
         this.minPrice = minPrice;
-        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
         this.description = description;
         this.likeCount = likeCount;
         this.isLiked = isLiked;

--- a/src/main/java/org/chzz/market/domain/product/dto/ProductDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/ProductDetailsResponse.java
@@ -1,10 +1,10 @@
 package org.chzz.market.domain.product.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Getter;
+import org.chzz.market.domain.image.dto.ImageResponse;
 import org.chzz.market.domain.product.entity.Product.Category;
 
 /**
@@ -22,7 +22,7 @@ public class ProductDetailsResponse {
     private final Boolean isLiked;
     private final Boolean isSeller;
     private final Category category;
-    private List<String> imageUrls;
+    private List<ImageResponse> images;
 
     @QueryProjection
     public ProductDetailsResponse(Long productId, String productName, String sellerNickname,
@@ -40,7 +40,7 @@ public class ProductDetailsResponse {
         this.category = category;
     }
 
-    public void addImageList(List<String> imageUrls) {
-        this.imageUrls = imageUrls;
+    public void addImageList(List<ImageResponse> images) {
+        this.images = images;
     }
 }

--- a/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
@@ -1,11 +1,15 @@
 package org.chzz.market.domain.product.dto;
 
+import static org.chzz.market.domain.product.entity.Product.Category;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.chzz.market.common.validation.annotation.ThousandMultiple;
-
-import static org.chzz.market.domain.product.entity.Product.*;
 
 @Getter
 @Builder
@@ -23,4 +27,6 @@ public class UpdateProductRequest {
     @ThousandMultiple
     @Min(value = 1000, message = "시작 가격은 최소 1,000원 이상, 1000의 배수이어야 합니다")
     private Integer minPrice;
+
+    private List<Long> deleteImageList;
 }

--- a/src/main/java/org/chzz/market/domain/product/dto/UpdateProductResponse.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/UpdateProductResponse.java
@@ -1,17 +1,17 @@
 package org.chzz.market.domain.product.dto;
 
 import java.util.List;
-import org.chzz.market.domain.image.entity.Image;
+import org.chzz.market.domain.image.dto.ImageResponse;
 import org.chzz.market.domain.product.entity.Product;
 import org.chzz.market.domain.product.entity.Product.Category;
 
-public record UpdateProductResponse (
+public record UpdateProductResponse(
         Long productId,
         String productName,
         String description,
         Category category,
         Integer minPrice,
-        List<String> imageUrls
+        List<ImageResponse> imageUrls
 ) {
     public static UpdateProductResponse from(Product product) {
         return new UpdateProductResponse(
@@ -21,7 +21,7 @@ public record UpdateProductResponse (
                 product.getCategory(),
                 product.getMinPrice(),
                 product.getImages().stream()
-                        .map(Image::getCdnPath)
+                        .map(ImageResponse::from)
                         .toList()
         );
     }

--- a/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -91,7 +91,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         product.name,
                         user.nickname,
                         product.minPrice,
-                        product.createdAt,
+                        product.updatedAt,
                         product.description,
                         product.likes.size().longValue(),
                         isProductLikedByUser(userId),

--- a/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -24,6 +24,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.util.QuerydslOrder;
 import org.chzz.market.common.util.QuerydslOrderProvider;
+import org.chzz.market.domain.image.dto.ImageResponse;
+import org.chzz.market.domain.image.dto.QImageResponse;
 import org.chzz.market.domain.image.entity.QImage;
 import org.chzz.market.domain.product.dto.ProductDetailsResponse;
 import org.chzz.market.domain.product.dto.ProductResponse;
@@ -102,13 +104,13 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 .fetchOne());
 
         return result.map(response -> {
-            List<String> imageUrls = jpaQueryFactory
-                    .select(image.cdnPath)
+            List<ImageResponse> images = jpaQueryFactory
+                    .select(new QImageResponse(image.id, image.cdnPath))
                     .from(image)
                     .where(image.product.id.eq(productId))
                     .orderBy(image.id.asc())
                     .fetch();
-            response.addImageList(imageUrls);
+            response.addImageList(images);
             return response;
         });
     }

--- a/src/test/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImplTest.java
@@ -111,7 +111,8 @@ class ProductRepositoryCustomImplTest {
             Pageable pageable = PageRequest.of(0, 10, Sort.by("expensive"));
 
             // when
-            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(), pageable);
+            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(),
+                    pageable);
 
             // then
             assertThat(result).isNotNull();
@@ -134,7 +135,8 @@ class ProductRepositoryCustomImplTest {
             Pageable pageable = PageRequest.of(0, 10, Sort.by("like"));
 
             // when
-            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(), pageable);
+            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(),
+                    pageable);
 
             // then
             assertThat(result.getContent()).isNotEmpty();
@@ -155,7 +157,8 @@ class ProductRepositoryCustomImplTest {
             Pageable pageable = PageRequest.of(0, 10, Sort.by("product-newest"));
 
             // when
-            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(), pageable);
+            Page<ProductResponse> result = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(),
+                    pageable);
 
             // then
             assertThat(result.getContent()).isNotEmpty();
@@ -195,7 +198,8 @@ class ProductRepositoryCustomImplTest {
         @DisplayName("1. 유효한 상품 ID로 상세 정보 조회")
         void findProductDetailsById() {
             // when
-            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product1.getId(), user2.getId());
+            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product1.getId(),
+                    user2.getId());
 
             // then
             assertThat(result).isPresent();
@@ -203,9 +207,13 @@ class ProductRepositoryCustomImplTest {
             assertThat(result.get().getMinPrice()).isEqualTo(10000);
             assertThat(result.get().getLikeCount()).isEqualTo(2);
             assertThat(result.get().getIsLiked()).isTrue(); // user2가 좋아요 한 상품
-            assertThat(result.get().getImageUrls()).contains("path/to/image1.jpg");
             assertThat(result.get().getIsSeller()).isFalse();
             assertThat(result.get().getCategory()).isEqualTo(ELECTRONICS);
+
+            assertThat(result.get().getImages()).isNotEmpty();
+            assertThat(result.get().getImages()).anySatisfy(imageResponse -> {
+                assertThat(imageResponse.imageUrl()).isEqualTo("path/to/image1.jpg");
+            });
         }
 
         @Test
@@ -222,7 +230,8 @@ class ProductRepositoryCustomImplTest {
         @DisplayName("3. 좋아요 하지 않은 사용자가 조회 시 'isLiked' false 반환")
         void findProductDetailsWithoutLike() {
             // when
-            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product3.getId(), user3.getId());
+            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product3.getId(),
+                    user3.getId());
 
             // then
             assertThat(result).isPresent();
@@ -238,7 +247,8 @@ class ProductRepositoryCustomImplTest {
             );
 
             // when
-            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(productWithoutLikes.getId(), user1.getId());
+            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(
+                    productWithoutLikes.getId(), user1.getId());
 
             // then
             assertThat(result).isPresent();
@@ -249,7 +259,8 @@ class ProductRepositoryCustomImplTest {
         @DisplayName("5. 다른 사용자의 상품 정보도 정상적으로 조회")
         void findProductDetailsOfOtherUser() {
             // when
-            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product2.getId(), user3.getId());
+            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product2.getId(),
+                    user3.getId());
 
             // then
             assertThat(result).isPresent();
@@ -260,7 +271,8 @@ class ProductRepositoryCustomImplTest {
         @DisplayName("6. 상품 정보에 생성 시간이 정확히 포함")
         void findProductDetailsWithCorrectCreatedAt() {
             // when
-            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product1.getId(), user1.getId());
+            Optional<ProductDetailsResponse> result = productRepository.findProductDetailsById(product1.getId(),
+                    user1.getId());
 
             // then
             assertThat(result).isPresent();
@@ -281,9 +293,14 @@ class ProductRepositoryCustomImplTest {
             assertThat(result.get().getMinPrice()).isEqualTo(10000);
             assertThat(result.get().getLikeCount()).isEqualTo(2);
             assertThat(result.get().getIsLiked()).isFalse(); // user2가 좋아요 한 상품
-            assertThat(result.get().getImageUrls()).contains("path/to/image1.jpg");
             assertThat(result.get().getIsSeller()).isFalse();
             assertThat(result.get().getCategory()).isEqualTo(ELECTRONICS);
+
+            // 이미지 확인
+            assertThat(result.get().getImages()).isNotEmpty();
+            assertThat(result.get().getImages()).anySatisfy(imageResponse -> {
+                assertThat(imageResponse.imageUrl()).isEqualTo("path/to/image1.jpg");
+            });
         }
 
     }
@@ -314,7 +331,8 @@ class ProductRepositoryCustomImplTest {
         void findMyProductsByUserIdWithNoProducts() {
             // given
             Pageable pageable = PageRequest.of(0, 10);
-            User newUser = userRepository.save(User.builder().providerId("9999").nickname("새로운사용자").email("new@test.com").build());
+            User newUser = userRepository.save(
+                    User.builder().providerId("9999").nickname("새로운사용자").email("new@test.com").build());
 
             // when
             Page<ProductResponse> result = productRepository.findProductsByNickname(newUser.getNickname(), pageable);
@@ -331,8 +349,10 @@ class ProductRepositoryCustomImplTest {
             Pageable secondPage = PageRequest.of(1, 2, Sort.by("expensive"));
 
             // when
-            Page<ProductResponse> firstResult = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(), firstPage);
-            Page<ProductResponse> secondResult = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(), secondPage);
+            Page<ProductResponse> firstResult = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(),
+                    firstPage);
+            Page<ProductResponse> secondResult = productRepository.findProductsByCategory(ELECTRONICS, user1.getId(),
+                    secondPage);
 
             // then
             assertThat(firstResult.getContent()).hasSize(2);
@@ -350,8 +370,10 @@ class ProductRepositoryCustomImplTest {
             Pageable expensivePageable = PageRequest.of(0, 10, Sort.by("expensive"));
 
             // when
-            Page<ProductResponse> newestResult = productRepository.findProductsByNickname(user1.getNickname(), newestPageable);
-            Page<ProductResponse> expensiveResult = productRepository.findProductsByNickname(user1.getNickname(), expensivePageable);
+            Page<ProductResponse> newestResult = productRepository.findProductsByNickname(user1.getNickname(),
+                    newestPageable);
+            Page<ProductResponse> expensiveResult = productRepository.findProductsByNickname(user1.getNickname(),
+                    expensivePageable);
 
             // then
             assertThat(newestResult.getContent()).extracting("productName")

--- a/src/test/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImplTest.java
@@ -276,9 +276,9 @@ class ProductRepositoryCustomImplTest {
 
             // then
             assertThat(result).isPresent();
-            assertThat(result.get().getCreatedAt()).isNotNull();
+            assertThat(result.get().getUpdatedAt()).isNotNull();
             // 생성 시간이 현재 시간보다 과거인지 확인
-            assertThat(result.get().getCreatedAt()).isBefore(LocalDateTime.now());
+            assertThat(result.get().getUpdatedAt()).isBefore(LocalDateTime.now());
         }
 
         @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-127]

## 📝작업 내용

- `ProductService` 상품 수정 이미지 로직 변경
    - 이미지 전체 삭제하는 방식에서 요청받은 `deleteImageList` 리스트의 이미지 ID에 해당하는 이미지 삭제하는 방식으로 변경
    - S3 이미지 삭제 로직을 제거했습니다. 
    - 사전등록 상품 수정 Repository 테스트 케이스를 추가했습니다.
  
- 사전 등록 상품 조회 DTO 수정
    - 시간 정보를 createdAt &rarr; updatedAt로 수정했습니다.
    - `ImageResponse` 이미지 응답 구조를 정의하여 이미지 ID, 이미지 URL 객체리스트를 응답 값으로 제공합니다

## ✅테스트 결과

> 사전 등록 상품 수정

![image](https://github.com/user-attachments/assets/f4f00ea6-42e2-4bb5-8869-378388ee0852)

> 2번 Image ID 사진 삭제, 새로운 이미지 추가 이후 사전 등록 상품 조회 

![image](https://github.com/user-attachments/assets/56790af7-51d0-407a-92f7-dc506ed8ae36)

> 사전 등록 상품 수정 테스트 코드 추가

![image](https://github.com/user-attachments/assets/0fba3e48-4197-48e9-8190-fef54c39d0b8)

## 🙏리뷰 요구사항(선택)

