### PR TITLE
fix: 상품 수정시 이미지 등록 버그 수정

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -12,7 +12,6 @@ categories:
 change-template: '- $TITLE #$NUMBER @$AUTHOR '
 template: |
   ## 이번 버전의 변경사항은 아래와 같아요
-  ---
   $CHANGES
 no-changes-template: '변경사항이 없어요'
 version-resolver:

--- a/src/main/java/org/chzz/market/domain/auction/service/register/AuctionRegisterService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/register/AuctionRegisterService.java
@@ -41,7 +41,7 @@ public class AuctionRegisterService implements AuctionRegistrationService {
         List<Image> saveImages = imageService.saveProductImageEntities(imageUrls);
         product.addImages(saveImages);
         Product savedProduct = productRepository.save(product);
-        imageService.validateImageSize(product.getId());
+        savedProduct.validateImageSize();
 
         Auction auction = createAuction(savedProduct);
         auctionRepository.save(auction);

--- a/src/main/java/org/chzz/market/domain/auction/service/register/AuctionRegisterService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/register/AuctionRegisterService.java
@@ -10,6 +10,7 @@ import org.chzz.market.domain.auction.dto.response.RegisterAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.RegisterResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.auction.repository.AuctionRepository;
+import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.service.ImageService;
 import org.chzz.market.domain.product.entity.Product;
 import org.chzz.market.domain.product.repository.ProductRepository;
@@ -36,11 +37,10 @@ public class AuctionRegisterService implements AuctionRegistrationService {
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         Product product = createProduct(request, user);
-        Product savedProduct = productRepository.save(product);
-
         List<String> imageUrls = imageService.uploadImages(images);
-        imageService.saveProductImageEntities(savedProduct, imageUrls);
-
+        List<Image> saveImages = imageService.saveProductImageEntities(imageUrls);
+        product.addImages(saveImages);
+        Product savedProduct = productRepository.save(product);
         imageService.validateImageSize(product.getId());
 
         Auction auction = createAuction(savedProduct);

--- a/src/main/java/org/chzz/market/domain/auction/service/register/PreRegisterService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/register/PreRegisterService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.chzz.market.domain.auction.dto.request.BaseRegisterRequest;
 import org.chzz.market.domain.auction.dto.response.PreRegisterResponse;
 import org.chzz.market.domain.auction.dto.response.RegisterResponse;
+import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.service.ImageService;
 import org.chzz.market.domain.product.entity.Product;
 import org.chzz.market.domain.product.repository.ProductRepository;
@@ -29,15 +30,12 @@ public class PreRegisterService implements AuctionRegistrationService {
     public RegisterResponse register(Long userId, BaseRegisterRequest request, List<MultipartFile> images) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));
-
         Product product = createProduct(request, user);
+        List<String> imageUrls = imageService.uploadImages(images);
+        List<Image> saveImages = imageService.saveProductImageEntities(imageUrls);
+        product.addImages(saveImages);
         Product savedProduct = productRepository.save(product);
-
-        if (images != null && !images.isEmpty()) {
-            List<String> imageUrls = imageService.uploadImages(images);
-            imageService.saveProductImageEntities(savedProduct, imageUrls);
-        }
-
+        imageService.validateImageSize(product.getId());
         return PreRegisterResponse.of(savedProduct.getId());
     }
 

--- a/src/main/java/org/chzz/market/domain/auction/service/register/PreRegisterService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/register/PreRegisterService.java
@@ -35,7 +35,7 @@ public class PreRegisterService implements AuctionRegistrationService {
         List<Image> saveImages = imageService.saveProductImageEntities(imageUrls);
         product.addImages(saveImages);
         Product savedProduct = productRepository.save(product);
-        imageService.validateImageSize(product.getId());
+        savedProduct.validateImageSize();
         return PreRegisterResponse.of(savedProduct.getId());
     }
 

--- a/src/main/java/org/chzz/market/domain/image/entity/Image.java
+++ b/src/main/java/org/chzz/market/domain/image/entity/Image.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
 import org.chzz.market.domain.product.entity.Product;
+import org.chzz.market.domain.user.entity.User;
 
 @Getter
 @Builder
@@ -43,4 +44,12 @@ public class Image extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    public void specifyProduct(Product product) {
+        this.product = product;
+    }
+
+    public void changeSequence(Integer newSequence) {
+        this.sequence = newSequence;
+    }
 }

--- a/src/main/java/org/chzz/market/domain/image/entity/Image.java
+++ b/src/main/java/org/chzz/market/domain/image/entity/Image.java
@@ -15,10 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
 import org.chzz.market.domain.product.entity.Product;
-import org.chzz.market.domain.user.entity.User;
 
 @Getter
 @Builder
@@ -31,14 +29,13 @@ import org.chzz.market.domain.user.entity.User;
 public class Image extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="image_id")
+    @Column(name = "image_id")
     private Long id;
 
     @Column(nullable = false)
     private String cdnPath;
 
     @Column
-    @Setter
     private int sequence;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/chzz/market/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/chzz/market/domain/image/repository/ImageRepository.java
@@ -4,5 +4,4 @@ import org.chzz.market.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
-    long countByProductId(Long productId);
 }

--- a/src/main/java/org/chzz/market/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/chzz/market/domain/image/repository/ImageRepository.java
@@ -1,18 +1,8 @@
 package org.chzz.market.domain.image.repository;
 
-import java.util.Set;
 import org.chzz.market.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
-    @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM Image i "
-            + " WHERE i.product.id = :productId"
-            + " AND i.id NOT IN :ids")
-    void deleteImagesNotContainsIdsOf(@Param("productId") Long productId,@Param("ids") Set<Long> ids);
-
     long countByProductId(Long productId);
 }

--- a/src/main/java/org/chzz/market/domain/image/service/ImageService.java
+++ b/src/main/java/org/chzz/market/domain/image/service/ImageService.java
@@ -96,8 +96,11 @@ public class ImageService {
         return images;
     }
 
+    /**
+     * 상품 수정 시 새로운 이미지 생성 및 저장
+     */
     @Transactional
-    public List<Image> uploadSequentialImages(Map<String, MultipartFile> newImages) {
+    public List<Image> uploadSequentialImages(Product product, Map<String, MultipartFile> newImages) {
         List<Image> images = newImages.entrySet().stream()
                 .map(entry -> {
                     int sequence = Integer.parseInt(entry.getKey());
@@ -106,6 +109,7 @@ public class ImageService {
                     return Image.builder()
                             .sequence(sequence)
                             .cdnPath(cdnPath)
+                            .product(product)
                             .build();
                 }).toList();
         imageRepository.saveAll(images);

--- a/src/main/java/org/chzz/market/domain/image/service/ImageService.java
+++ b/src/main/java/org/chzz/market/domain/image/service/ImageService.java
@@ -3,7 +3,6 @@ package org.chzz.market.domain.image.service;
 import static org.chzz.market.domain.image.error.ImageErrorCode.IMAGE_DELETE_FAILED;
 import static org.chzz.market.domain.image.error.ImageErrorCode.INVALID_IMAGE_EXTENSION;
 import static org.chzz.market.domain.image.error.ImageErrorCode.MAX_IMAGE_COUNT_EXCEEDED;
-import static org.chzz.market.domain.image.error.ImageErrorCode.NOT_FOUND;
 import static org.chzz.market.domain.image.error.ImageErrorCode.NO_IMAGES_PROVIDED;
 
 import com.amazonaws.AmazonServiceException;
@@ -14,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -82,16 +80,13 @@ public class ImageService {
      * 상품에 대한 이미지 Entity 생성 및 저장
      */
     @Transactional
-    public List<Image> saveProductImageEntities(Product product, List<String> cdnPaths) {
+    public List<Image> saveProductImageEntities(List<String> cdnPaths) {
         List<Image> images = IntStream.range(0, cdnPaths.size())
                 .mapToObj(i -> Image.builder()
                         .cdnPath(cdnPaths.get(i))
-                        .product(product)
                         .sequence((i + 1))
                         .build())
                 .toList();
-
-        imageRepository.saveAll(images);
         return images;
     }
 
@@ -116,32 +111,17 @@ public class ImageService {
     }
 
     /**
-     * @param productId 상품 ID
-     * @param imageIds  남아있을 이미지 ID
+     * 기존 이미지의 시퀀스를 업데이트하는 메서드
      */
     @Transactional
-    public void deleteImagesNotContainsIdsOf(Long productId, Set<Long> imageIds) {
-        imageRepository.deleteImagesNotContainsIdsOf(productId, imageIds);
-    }
-
-    /**
-     * 시퀀스 업데이트
-     */
-    @Transactional
-    public void updateSequence(Map<Long, Integer> imageSequence) {
-        imageSequence.forEach((imageId, sequence) -> {
-            Image image = imageRepository.findById(imageId)
-                    .orElseThrow(() -> new ImageException(NOT_FOUND));
-            image.setSequence(sequence);
+    public void updateImageSequences(List<Image> imagesToUpdate, Map<Long, Integer> imageSequence) {
+        imagesToUpdate.forEach(image -> {
+            Long imageId = image.getId();
+            Integer newSequence = imageSequence.get(imageId);
+            if (newSequence != null) {
+                image.changeSequence(newSequence); // 이미지의 시퀀스 업데이트
+            }
         });
-    }
-
-    /**
-     * 기존 이미지중 제거할 이미지 삭제 후 시퀀스 수정
-     */
-    public void updateExistingImages(Product product, Map<Long, Integer> imageSequence) {
-        deleteImagesNotContainsIdsOf(product.getId(), imageSequence.keySet());//제거될 id들을 받아서 삭제
-        updateSequence(imageSequence);// 남아있는 시퀀스 매김
     }
 
     /**

--- a/src/main/java/org/chzz/market/domain/image/service/ImageService.java
+++ b/src/main/java/org/chzz/market/domain/image/service/ImageService.java
@@ -2,8 +2,6 @@ package org.chzz.market.domain.image.service;
 
 import static org.chzz.market.domain.image.error.ImageErrorCode.IMAGE_DELETE_FAILED;
 import static org.chzz.market.domain.image.error.ImageErrorCode.INVALID_IMAGE_EXTENSION;
-import static org.chzz.market.domain.image.error.ImageErrorCode.MAX_IMAGE_COUNT_EXCEEDED;
-import static org.chzz.market.domain.image.error.ImageErrorCode.NO_IMAGES_PROVIDED;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
@@ -51,19 +49,6 @@ public class ImageService {
                 .toList();
         log.info("업로드 된 이미지 리스트: {}", uploadedUrls);
         return uploadedUrls;
-    }
-
-    /**
-     * 이미지 갯수의 범위 확인
-     */
-    public void validateImageSize(Long productId) {
-        long count = imageRepository.countByProductId(productId);
-        // 삭제 연산 이후 갯수 확인
-        if (count < 1) {
-            throw new ImageException(NO_IMAGES_PROVIDED);
-        } else if (count > 5) {
-            throw new ImageException(MAX_IMAGE_COUNT_EXCEEDED);
-        }
     }
 
     /**

--- a/src/main/java/org/chzz/market/domain/image/service/ImageService.java
+++ b/src/main/java/org/chzz/market/domain/image/service/ImageService.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.error.exception.ImageException;
 import org.chzz.market.domain.image.repository.ImageRepository;
-import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.entity.Product;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -140,9 +139,9 @@ public class ImageService {
     /**
      * 기존 이미지중 제거할 이미지 삭제 후 시퀀스 수정
      */
-    public void updateExistingImages(Product product, UpdateProductRequest request) {
-        deleteImagesNotContainsIdsOf(product.getId(), request.getImageSequence().keySet());//제거될 id들을 받아서 삭제
-        updateSequence(request.getImageSequence());// 남아있는 시퀀스 매김
+    public void updateExistingImages(Product product, Map<Long, Integer> imageSequence) {
+        deleteImagesNotContainsIdsOf(product.getId(), imageSequence.keySet());//제거될 id들을 받아서 삭제
+        updateSequence(imageSequence);// 남아있는 시퀀스 매김
     }
 
     /**

--- a/src/main/java/org/chzz/market/domain/product/entity/Product.java
+++ b/src/main/java/org/chzz/market/domain/product/entity/Product.java
@@ -1,5 +1,8 @@
 package org.chzz.market.domain.product.entity;
 
+import static org.chzz.market.domain.image.error.ImageErrorCode.MAX_IMAGE_COUNT_EXCEEDED;
+import static org.chzz.market.domain.image.error.ImageErrorCode.NO_IMAGES_PROVIDED;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.domain.base.entity.BaseTimeEntity;
 import org.chzz.market.domain.image.entity.Image;
+import org.chzz.market.domain.image.error.exception.ImageException;
 import org.chzz.market.domain.like.entity.Like;
 import org.chzz.market.domain.product.dto.UpdateProductRequest;
 import org.chzz.market.domain.product.error.ProductErrorCode;
@@ -143,6 +147,15 @@ public class Product extends BaseTimeEntity {
                 .map(like -> like.getUser().getId())
                 .distinct()
                 .toList();
+    }
+
+    public void validateImageSize() {
+        long count = this.images.size();
+        if (count < 1) {
+            throw new ImageException(NO_IMAGES_PROVIDED);
+        } else if (count > 5) {
+            throw new ImageException(MAX_IMAGE_COUNT_EXCEEDED);
+        }
     }
 
 }

--- a/src/main/java/org/chzz/market/domain/product/entity/Product.java
+++ b/src/main/java/org/chzz/market/domain/product/entity/Product.java
@@ -69,7 +69,7 @@ public class Product extends BaseTimeEntity {
     private List<Like> likes = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "product", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
     @Getter
@@ -114,7 +114,21 @@ public class Product extends BaseTimeEntity {
     }
 
     public void addImages(List<Image> images) {
-        this.images.addAll(images);
+        images.forEach(this::addImage);
+    }
+
+    public void removeImages(List<Image> images) {
+        images.forEach(this::removeImage);
+    }
+
+    private void addImage(Image image) {
+        images.add(image);
+        image.specifyProduct(this);
+    }
+
+    private void removeImage(Image image) {
+        images.remove(image);
+        image.specifyProduct(null);
     }
 
     public Image getFirstImage() {

--- a/src/main/java/org/chzz/market/domain/product/entity/Product.java
+++ b/src/main/java/org/chzz/market/domain/product/entity/Product.java
@@ -102,7 +102,6 @@ public class Product extends BaseTimeEntity {
         likes.remove(like);
     }
 
-
     public void update(UpdateProductRequest modifiedProduct) {
         this.name = modifiedProduct.getProductName();
         this.description = modifiedProduct.getDescription();
@@ -114,11 +113,9 @@ public class Product extends BaseTimeEntity {
         return this.user.getId().equals(userId);
     }
 
-
     public void addImages(List<Image> images) {
         this.images.addAll(images);
     }
-
 
     public Image getFirstImage() {
         return images.stream()

--- a/src/main/java/org/chzz/market/domain/product/service/ProductService.java
+++ b/src/main/java/org/chzz/market/domain/product/service/ProductService.java
@@ -190,7 +190,7 @@ public class ProductService {
         if (!newImages.isEmpty()) {
             uploadAndAddNewImages(product, newImages);
         }
-        imageService.validateImageSize(product.getId());
+        product.validateImageSize();
     }
 
     /**
@@ -240,7 +240,6 @@ public class ProductService {
                 imagesToRemove.add(image); // 삭제할 이미지
             }
         });
-
         product.removeImages(imagesToRemove); // 삭제할 이미지 처리
         imageService.updateImageSequences(imagesToUpdate, imageSequence); // 시퀀스 업데이트할 이미지 처리
     }

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -41,6 +41,7 @@ import org.chzz.market.domain.auction.error.AuctionException;
 import org.chzz.market.domain.auction.repository.AuctionRepository;
 import org.chzz.market.domain.auction.service.register.AuctionRegisterService;
 import org.chzz.market.domain.auction.service.register.PreRegisterService;
+import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.service.ImageService;
 import org.chzz.market.domain.product.entity.Product;
 import org.chzz.market.domain.product.error.ProductErrorCode;
@@ -154,6 +155,7 @@ class AuctionServiceTest {
             List<MultipartFile> images = createMockMultipartFiles();
 
             Product savedProduct = ProductTestFactory.createProduct(preRegisterRequest, user);
+            savedProduct.addImages(createExistingImages(savedProduct));
             ReflectionTestUtils.setField(savedProduct, "id", productId);
 
             when(productRepository.save(any(Product.class))).thenReturn(savedProduct);
@@ -217,6 +219,7 @@ class AuctionServiceTest {
             List<MultipartFile> images = createMockMultipartFiles();
 
             Product product = ProductTestFactory.createProduct(registerAuctionRequest, user);
+            product.addImages(createExistingImages(product));
             ReflectionTestUtils.setField(product, "id", productId);
 
             Auction auction = AuctionTestFactory.createAuction(product, registerAuctionRequest, PROCEEDING);
@@ -707,5 +710,12 @@ class AuctionServiceTest {
         MultipartFile mockFile2 = new MockMultipartFile(
                 "testImage2.jpg", "testImage2.jpg", "image/jpeg", "test image content 2".getBytes());
         return List.of(mockFile1, mockFile2);
+    }
+
+    private List<Image> createExistingImages(Product product) {
+        return List.of(
+                new Image(1L, "existingImage1.jpg", 1, product),
+                new Image(2L, "existingImage2.jpg", 2, product)
+        );
     }
 }

--- a/src/test/java/org/chzz/market/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/product/service/ProductServiceTest.java
@@ -79,6 +79,7 @@ public class ProductServiceTest {
 
         image = Image.builder()
                 .product(existingProduct)
+                .id(1L)
                 .cdnPath("path/to/image.jpg")
                 .build();
 
@@ -287,7 +288,7 @@ public class ProductServiceTest {
 
             // then
             assertEquals(2, response.imageUrls().size());
-            verify(imageService).updateExistingImages(existingProduct, updateRequest.getImageSequence());
+            verify(imageService).updateImageSequences(new ArrayList<>(), updateRequest.getImageSequence());
 
             assertThat(response.imageUrls().get(0).imageUrl()).isEqualTo("new_image1.jpg");
             assertThat(response.imageUrls().get(0).imageId()).isEqualTo(1L);
@@ -338,7 +339,7 @@ public class ProductServiceTest {
             );
 
             // Then
-            verify(imageService).updateExistingImages(existingProduct, updateRequest.getImageSequence());
+            verify(imageService).updateImageSequences(new ArrayList<>(), updateRequest.getImageSequence());
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-137]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 이미지 등록 및 삭제시 연관관계 메서드 사용으로 변경하였습니다.
- 상품 수정시 RequestParam에 dto 가 포함되서 해당 dto는 map에서 삭제하도록 했습니다.
- Product, Image 각각 도메인 메서드를 활용하였습니다.
- Product에 이미지 리스트에 `CascadeType.PERSIST`,`orphanRemoval = true` 추가하였습니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

![스크린샷 2024-10-11 오후 7 56 22](https://github.com/user-attachments/assets/40d38dfb-0704-406e-af73-6a39d6d5ebca)


## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->



[CHZZ-137]: https://chzz-market.atlassian.net/browse/CHZZ-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ