### PR TITLE
refactor: 내가 등록한 경매 상태값에 따라 API 분리

### DIFF
--- a/.github/workflows/deployment-config.yml
+++ b/.github/workflows/deployment-config.yml
@@ -54,18 +54,18 @@ jobs:
 
       # 테스트 실행
       - name: Test with Gradle
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-          CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
-          CLOUD_AWS_REGION_STATIC: ${{ secrets.AWS_REGION }}
-          CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          CLOUD_AWS_CLOUDFRONT_DOMAIN: ${{ secrets.AWS_CLOUDFRONT_DOMAIN }}
-          PAYMENT_TOSS_CLIENT_KEY: ${{ secrets.TEST_CLIENT_KEY }}
-          PAYMENT_TOSS_SECURITY_KEY: ${{ secrets.TEST_SECRET_KEY }}
-          SPRING_DATA_REDIS_HOST: ${{ secrets.TEST_REDIS_HOST }}
-          SPRING_DATA_REDIS_PORT: ${{ secrets.TEST_REDIS_PORT }}
-        run: ./gradlew test --no-daemon
+        run: |
+          ./gradlew -Dspring.profiles.active=test \
+          -Dcloud.aws.credentials.access-key=${{ secrets.S3_AWS_ACCESS_KEY_ID }} \
+          -Dcloud.aws.credentials.secret-key=${{ secrets.S3_AWS_SECRET_ACCESS_KEY }} \
+          -Dcloud.aws.region.static=${{ secrets.AWS_REGION }} \
+          -Dcloud.aws.s3.bucket=${{ secrets.AWS_S3_BUCKET }} \
+          -Dcloud.aws.cloudfront.domain=${{ secrets.AWS_CLOUDFRONT_DOMAIN }} \
+          -Dpayment.toss.client-key=${{ secrets.TEST_CLIENT_KEY }} \
+          -Dpayment.toss.security-key=${{ secrets.TEST_SECRET_KEY }} \
+          -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
+          -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
+          test
 
   # CD 단계: 배포 작업
   deploy:

--- a/.github/workflows/deployment-config.yml
+++ b/.github/workflows/deployment-config.yml
@@ -1,10 +1,10 @@
-name: CD
-run-name: Running
+name: CI/CD Workflow
+run-name: Running CI and CD
+
 on:
-  push:
+  pull_request:
     branches:
-      - release/*
-      - hotfix/*
+      - main
 
 env:
   AWS_REGION: ap-northeast-2
@@ -12,10 +12,67 @@ env:
   ECS_SERVICE: chzz-market
 
 jobs:
+  # CI 단계: 코드 빌드 및 테스트
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # 소스 코드 체크아웃
+      - uses: actions/checkout@v4
+
+      # JDK 설정
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: 'gradle'
+
+      # Gradle 설정 및 캐시 최적화
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # Gradle 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Redis 서버 실행
+      - name: Redis Server in GitHub Actions
+        uses: supercharge/redis-github-action@1.8.0
+
+      # Gradle 빌드 (테스트 제외)
+      - name: Build with Gradle
+        run: ./gradlew build -x test --no-daemon
+
+      # 테스트 실행
+      - name: Test with Gradle
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
+          CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
+          CLOUD_AWS_REGION_STATIC: ${{ secrets.AWS_REGION }}
+          CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          CLOUD_AWS_CLOUDFRONT_DOMAIN: ${{ secrets.AWS_CLOUDFRONT_DOMAIN }}
+          PAYMENT_TOSS_CLIENT_KEY: ${{ secrets.TEST_CLIENT_KEY }}
+          PAYMENT_TOSS_SECURITY_KEY: ${{ secrets.TEST_SECRET_KEY }}
+          SPRING_DATA_REDIS_HOST: ${{ secrets.TEST_REDIS_HOST }}
+          SPRING_DATA_REDIS_PORT: ${{ secrets.TEST_REDIS_PORT }}
+        run: ./gradlew test --no-daemon
+
+  # CD 단계: 배포 작업
   deploy:
+    needs: build  # CI 단계가 성공한 후에 배포 진행
     runs-on: ubuntu-latest
     steps:
-      - name: check out
+      - name: Check out
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -39,13 +96,7 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'corretto'
-
-      - name: AWS credential 설정
+      - name: AWS credentials 설정
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: ${{ env.AWS_REGION }}
@@ -61,12 +112,7 @@ jobs:
           aws s3 cp s3://chzzmarket-production-storage/chzz-production-properties/application-prod.yml \
           ./src/main/resources/application-prod.yml
 
-      - name: gradle 실행 권한 부여
-        run: chmod +x ./gradlew
-
-      - name: gradle 빌드
-        run: ./gradlew build -x test
-
+      # Docker 이미지 빌드 및 ECR 배포
       - name: Docker 이미지 빌드 및 ECR 배포
         id: build-image
         env:
@@ -80,11 +126,11 @@ jobs:
       - name: EC2로 파일 복사 (compose.yaml 및 nginx.conf 포함)
         uses: appleboy/scp-action@master
         with:
-            host: ${{ secrets.EC2_IP }}
-            username: ${{ secrets.EC2_USERNAME }}
-            key: ${{ secrets.EC2_SSH_KEY }}
-            source: './compose.yaml,./nginx.conf'
-            target: '/home/ec2-user'
+          host: ${{ secrets.EC2_IP }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: './compose.yaml,./nginx.conf'
+          target: '/home/ec2-user'
 
       - name: EC2에서 Docker Compose를 통한 애플리케이션 실행
         uses: appleboy/ssh-action@master

--- a/.github/workflows/intergration-config.yml
+++ b/.github/workflows/intergration-config.yml
@@ -48,15 +48,15 @@ jobs:
 
       # 테스트 실행
       - name: Test with Gradle
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
-          CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
-          CLOUD_AWS_REGION_STATIC: ${{ secrets.AWS_REGION }}
-          CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          CLOUD_AWS_CLOUDFRONT_DOMAIN: ${{ secrets.AWS_CLOUDFRONT_DOMAIN }}
-          PAYMENT_TOSS_CLIENT_KEY: ${{ secrets.TEST_CLIENT_KEY }}
-          PAYMENT_TOSS_SECURITY_KEY: ${{ secrets.TEST_SECRET_KEY }}
-          SPRING_DATA_REDIS_HOST: ${{ secrets.TEST_REDIS_HOST }}
-          SPRING_DATA_REDIS_PORT: ${{ secrets.TEST_REDIS_PORT }}
-        run: ./gradlew test --no-daemon
+        run: |
+          ./gradlew -Dspring.profiles.active=test \
+          -Dcloud.aws.credentials.access-key=${{ secrets.S3_AWS_ACCESS_KEY_ID }} \
+          -Dcloud.aws.credentials.secret-key=${{ secrets.S3_AWS_SECRET_ACCESS_KEY }} \
+          -Dcloud.aws.region.static=${{ secrets.AWS_REGION }} \
+          -Dcloud.aws.s3.bucket=${{ secrets.AWS_S3_BUCKET }} \
+          -Dcloud.aws.cloudfront.domain=${{ secrets.AWS_CLOUDFRONT_DOMAIN }} \
+          -Dpayment.toss.client-key=${{ secrets.TEST_CLIENT_KEY }} \
+          -Dpayment.toss.security-key=${{ secrets.TEST_SECRET_KEY }} \
+          -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
+          -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
+          test

--- a/.github/workflows/intergration-config.yml
+++ b/.github/workflows/intergration-config.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Gradle 빌드 (테스트 제외)
       - name: Build with Gradle
-        run: ./gradlew build -x test --no-daemon --info
+        run: ./gradlew build -x test --no-daemon
 
       # 테스트 실행
       - name: Test with Gradle

--- a/.github/workflows/intergration-config.yml
+++ b/.github/workflows/intergration-config.yml
@@ -1,8 +1,9 @@
-name: Java CI with Gradle!
+name: Java CI with Gradle
 
 on:
   pull_request:
-    branches: ["develop"]
+    branches:
+      - develop
 
 jobs:
   build:
@@ -11,47 +12,51 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'corretto'
-        cache: 'gradle'
+      # 소스 코드 체크아웃
+      - uses: actions/checkout@v4
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
-    
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    
-    - name: Cache Gradle packages
-      uses: actions/cache@v3
-      with:
-        path: |  
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      # JDK 설정
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: 'gradle'
 
-    - name: Redis Server in GitHub Actions
-      uses: supercharge/redis-github-action@1.8.0
+      # Gradle 설정 및 캐시 최적화
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Build with Gradle
-      run: ./gradlew build -x test -i
-    
-    - name: Test with Gradle
-      run: |
-        ./gradlew -Dspring.profiles.active=test \
-        -Dcloud.aws.credentials.access-key=${{ secrets.S3_AWS_ACCESS_KEY_ID }} \
-        -Dcloud.aws.credentials.secret-key=${{ secrets.S3_AWS_SECRET_ACCESS_KEY }} \
-        -Dcloud.aws.region.static=${{ secrets.AWS_REGION }} \
-        -Dcloud.aws.s3.bucket=${{ secrets.AWS_S3_BUCKET }} \
-        -Dcloud.aws.cloudfront.domain=${{ secrets.AWS_CLOUDFRONT_DOMAIN }} \
-        -Dpayment.toss.client-key=${{ secrets.TEST_CLIENT_KEY }} \
-        -Dpayment.toss.security-key=${{ secrets.TEST_SECRET_KEY }} \
-        -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
-        -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
-        test -i
-        
+      # Gradle 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Redis 서버 실행
+      - name: Redis Server in GitHub Actions
+        uses: supercharge/redis-github-action@1.8.0
+
+      # Gradle 빌드 (테스트 제외)
+      - name: Build with Gradle
+        run: ./gradlew build -x test --no-daemon --info
+
+      # 테스트 실행
+      - name: Test with Gradle
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
+          CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
+          CLOUD_AWS_REGION_STATIC: ${{ secrets.AWS_REGION }}
+          CLOUD_AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          CLOUD_AWS_CLOUDFRONT_DOMAIN: ${{ secrets.AWS_CLOUDFRONT_DOMAIN }}
+          PAYMENT_TOSS_CLIENT_KEY: ${{ secrets.TEST_CLIENT_KEY }}
+          PAYMENT_TOSS_SECURITY_KEY: ${{ secrets.TEST_SECRET_KEY }}
+          SPRING_DATA_REDIS_HOST: ${{ secrets.TEST_REDIS_HOST }}
+          SPRING_DATA_REDIS_PORT: ${{ secrets.TEST_REDIS_PORT }}
+        run: ./gradlew test --no-daemon

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -152,6 +152,15 @@ public class AuctionController {
     }
 
     /**
+     * 사용자의 종료된 경매 목록 조회
+     */
+    @GetMapping("/users/ended")
+    public ResponseEntity<?> getEndedAuctions(@LoginUser Long userId,
+                                              @PageableDefault(sort = "newest") Pageable pageable) {
+        return ResponseEntity.ok(auctionService.getEndedAuctionListByUserId(userId, pageable));
+    }
+
+    /**
      * 경매 등록
      */
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -125,7 +125,7 @@ public class AuctionController {
     }
 
     /**
-     * 사용자 경매 상품 목록 조회 (토큰)
+     * 사용자가 등록한 모든 경매 목록 조회 현재 사용 X
      */
     @GetMapping("/users")
     public ResponseEntity<?> getUserRegisteredAuction(@LoginUser Long userId,
@@ -134,12 +134,21 @@ public class AuctionController {
     }
 
     /**
-     * 사용자 경매 상품 목록 조회 (닉네임)
+     * 사용자 경매 상품 목록 조회 (닉네임) 현재 사용 X
      */
     @GetMapping("/users/{nickname}")
     public ResponseEntity<Page<UserAuctionResponse>> getUserAuctionList(@PathVariable String nickname,
                                                                         @PageableDefault(sort = "newest") Pageable pageable) {
         return ResponseEntity.ok(auctionService.getAuctionListByNickname(nickname, pageable));
+    }
+
+    /**
+     * 사용자의 진행 중인 경매 목록 조회
+     */
+    @GetMapping("/users/proceeding")
+    public ResponseEntity<?> getProceedingAuctions(@LoginUser Long userId,
+                                                   @PageableDefault(sort = "newest") Pageable pageable) {
+        return ResponseEntity.ok(auctionService.getProceedingAuctionListByUserId(userId, pageable));
     }
 
     /**

--- a/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
@@ -27,7 +27,7 @@ import org.chzz.market.domain.auction.type.AuctionRegisterType;
 public abstract class BaseRegisterRequest {
 
     @NotBlank
-    @Size(min = 2, message = "제목은 최소 2글자 이상이어야 합니다")
+    @Size(min = 2, max = 30, message = "제목은 최소 2글자 이상 30자 이하여야 합니다")
     protected String productName;
 
     @NotNull

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/UserEndedAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/UserEndedAuctionResponse.java
@@ -1,0 +1,24 @@
+package org.chzz.market.domain.auction.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+
+/**
+ * 사용자의 종료된 경매 목록 조회
+ */
+public record UserEndedAuctionResponse(
+        Long auctionId,
+        String productName,
+        String imageUrl,
+        Long minPrice,
+        Long participantCount,
+        Long winningBidAmount,
+        Boolean isWon, // 낙찰 유무
+        Boolean isPaid, // 결제 유무
+        LocalDateTime createAt
+) {
+
+    @QueryProjection
+    public UserEndedAuctionResponse {
+    }
+}

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.chzz.market.domain.auction.dto.response.AuctionResponse;
 import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.chzz.market.domain.user.dto.response.ParticipationCountsResponse;
@@ -112,4 +113,13 @@ public interface AuctionRepositoryCustom {
      * @return 진행 중인 경매 목록을 포함한 페이징 결과
      */
     Page<UserAuctionResponse> findProceedingAuctionByUserId(Long userId, Pageable pageable);
+
+    /**
+     * 사용자 ID에 해당하는 종료된 경매 목록을 페이징항여 조회합니다.
+     *
+     * @param userId   경매를 조회할 사용자 ID
+     * @param pageable 페이징 정보 (페이지 번호, 페이지 크기 등)
+     * @return 종료된 경매 목록을 포함한 페이징 결과
+     */
+    Page<UserEndedAuctionResponse> findEndedAuctionByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
@@ -2,8 +2,12 @@ package org.chzz.market.domain.auction.repository;
 
 import java.util.List;
 import java.util.Optional;
-
-import org.chzz.market.domain.auction.dto.response.*;
+import org.chzz.market.domain.auction.dto.response.AuctionDetailsResponse;
+import org.chzz.market.domain.auction.dto.response.AuctionResponse;
+import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.chzz.market.domain.user.dto.response.ParticipationCountsResponse;
 import org.springframework.data.domain.Page;
@@ -22,7 +26,8 @@ public interface AuctionRepositoryCustom {
 
     /**
      * 사용자가 참여한(입찰한) 경매 상세 정보를 조회합니다.
-     * @param userId - 사용자 ID
+     *
+     * @param userId   - 사용자 ID
      * @param pageable - 페이징 정보
      * @return - 페이징된 경매 응답 리스트
      */
@@ -39,8 +44,9 @@ public interface AuctionRepositoryCustom {
 
     /**
      * 경매 ID로 경매 간단 상세 정보를 조회합니다.
+     *
      * @param auctionId 경매 ID
-     * @return          경매 간단 상세정보 응답
+     * @return 경매 간단 상세정보 응답
      */
     Optional<SimpleAuctionResponse> findSimpleAuctionDetailsById(Long auctionId);
 
@@ -54,7 +60,7 @@ public interface AuctionRepositoryCustom {
     Page<UserAuctionResponse> findAuctionsByNickname(String nickname, Pageable pageable);
 
     /**
-     * @param userId 사용자 ID
+     * @param userId   사용자 ID
      * @param pageable 페이징 정보
      * @return 페이징된 사용자 경매 등록 기록
      */
@@ -62,29 +68,33 @@ public interface AuctionRepositoryCustom {
 
     /**
      * 홈 화면의 베스트 경매 조회
+     *
      * @return 입찰 기록이 많은 경매 정보
      */
     List<AuctionResponse> findBestAuctions();
 
     /**
      * 홈 화면의 임박 경매 조회
+     *
      * @return 경매 종료까지 1시간 이내인 경매 정보
      */
     List<AuctionResponse> findImminentAuctions();
 
     /**
      * 사용자가 낙찰한 경매 이력을 조회합니다.
-     * @param userId    사용자 ID
-     * @param pageable  페이징 정보
-     * @return          페이징된 낙찰 경매 응답 리스트
+     *
+     * @param userId   사용자 ID
+     * @param pageable 페이징 정보
+     * @return 페이징된 낙찰 경매 응답 리스트
      */
     Page<WonAuctionResponse> findWonAuctionHistoryByUserId(Long userId, Pageable pageable);
 
     /**
      * 사용자가 낙찰하지 못한 경매 이력을 조회합니다.
+     *
      * @param userId   사용자 ID
      * @param pageable 페이징 정보
-     * @return         페이징된 낙찰 실패 경매 응답 리스트
+     * @return 페이징된 낙찰 실패 경매 응답 리스트
      */
     Page<LostAuctionResponse> findLostAuctionHistoryByUserId(Long userId, Pageable pageable);
 
@@ -93,4 +103,13 @@ public interface AuctionRepositoryCustom {
      * @return 사용자가 참여한 상태별 경매들의 수
      */
     ParticipationCountsResponse getParticipationCounts(Long userId);
+
+    /**
+     * 주어진 사용자 ID에 해당하는 진행 중인 경매 목록을 페이징하여 조회합니다.
+     *
+     * @param userId   경매를 조회할 사용자 ID
+     * @param pageable 페이징 정보 (페이지 번호, 페이지 크기 등)
+     * @return 진행 중인 경매 목록을 포함한 페이징 결과
+     */
+    Page<UserAuctionResponse> findProceedingAuctionByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -9,6 +9,8 @@ import static org.chzz.market.domain.bid.entity.Bid.BidStatus.ACTIVE;
 import static org.chzz.market.domain.bid.entity.Bid.BidStatus.CANCELLED;
 import static org.chzz.market.domain.bid.entity.QBid.bid;
 import static org.chzz.market.domain.image.entity.QImage.image;
+import static org.chzz.market.domain.payment.entity.QPayment.payment;
+import static org.chzz.market.domain.payment.entity.Status.DONE;
 import static org.chzz.market.domain.product.entity.QProduct.product;
 import static org.chzz.market.domain.user.entity.QUser.user;
 
@@ -40,9 +42,11 @@ import org.chzz.market.domain.auction.dto.response.QAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.QLostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.QSimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.QUserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.QUserEndedAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.QWonAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.image.entity.QImage;
 import org.chzz.market.domain.product.entity.Product.Category;
@@ -319,7 +323,6 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
     public Page<WonAuctionResponse> findWonAuctionHistoryByUserId(Long userId, Pageable pageable) {
         JPAQuery<?> baseQuery = getActualParticipatedAuction(userId)
                 .join(auction.product, product)
-//                .join(product.user, user)//?? 안쓰는데
                 .where(auction.winnerId.eq(userId)
                         .and(auction.status.eq(ENDED)));
 
@@ -468,6 +471,41 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Page<UserEndedAuctionResponse> findEndedAuctionByUserId(Long userId, Pageable pageable) {
+        JPAQuery<?> baseQuery = jpaQueryFactory
+                .from(auction)
+                .join(auction.product, product)
+                .where(product.user.id.eq(userId).and(auction.status.eq(ENDED)));
+
+        // 종료된 경매 조회 쿼리
+        List<UserEndedAuctionResponse> result = baseQuery
+                .select(new QUserEndedAuctionResponse(
+                        auction.id,
+                        product.name,
+                        image.cdnPath,
+                        product.minPrice.longValue(),
+                        getBidCount(),
+                        getWinningBidAmount(),
+                        auction.winnerId.isNotNull(),
+                        payment.id.isNotNull(),
+                        auction.createdAt
+                ))
+                .leftJoin(image).on(image.product.id.eq(product.id)
+                        .and(image.id.eq(getFirstImageId())))
+                .leftJoin(payment).on(payment.auction.id.eq(auction.id).and(payment.status.eq(DONE)))
+                .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 경매 수를 계산하는 쿼리
+        JPAQuery<Long> countQuery = baseQuery
+                .select(auction.count());
+
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
+    }
+
     /**
      * @param userId 사용자 pk
      * @return 실제 사용자가 참여한 경매(취소된 입찰 제외)
@@ -535,6 +573,20 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
     private static NumberExpression<Integer> timeRemaining() {
         return Expressions.numberTemplate(Integer.class,
                 "GREATEST(0, TIMESTAMPDIFF(SECOND, CURRENT_TIMESTAMP, {0}))", auction.endDateTime); // 음수면 0으로 처리
+    }
+
+    /**
+     * 경매의 낙찰 금액을 조회합니다.
+     *
+     * @return 낙찰금액
+     */
+    private JPQLQuery<Long> getWinningBidAmount() {
+        return JPAExpressions.select(bid.amount.max().coalesce(0L))
+                .from(bid)
+                .where(
+                        bid.auction.id.eq(auction.id),
+                        bid.status.eq(ACTIVE)
+                );
     }
 
     private BooleanBuilder userIdEq(Long userId) {

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -142,6 +142,13 @@ public class AuctionService {
     }
 
     /**
+     * 사용자가 등록한 종료된 경매 목록 조회
+     */
+    public Page<?> getEndedAuctionListByUserId(Long userId, Pageable pageable) {
+        return auctionRepository.findEndedAuctionByUserId(userId, pageable);
+    }
+
+    /**
      * 사전 등록 상품 경매 전환 처리
      */
     @Transactional

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -125,7 +125,20 @@ public class AuctionService {
      */
     public List<AuctionResponse> getImminentAuctionList() {
         return auctionRepository.findImminentAuctions();
+    }
 
+    /**
+     * 사용자가 등록한 모든 경매 목록 조회
+     */
+    public Page<UserAuctionResponse> getAuctionListByUserId(Long userId, Pageable pageable) {
+        return auctionRepository.findAuctionsByUserId(userId, pageable);
+    }
+
+    /**
+     * 사용자가 등록한 진행중인 경매 목록 조회
+     */
+    public Page<UserAuctionResponse> getProceedingAuctionListByUserId(Long userId, Pageable pageable) {
+        return auctionRepository.findProceedingAuctionByUserId(userId, pageable);
     }
 
     /**
@@ -241,9 +254,5 @@ public class AuctionService {
             eventPublisher.publishEvent(NotificationEvent.createSimpleNotification(nonWinnerIds, AUCTION_NON_WINNER,
                     AUCTION_NON_WINNER.getMessage(productName), firstImage)); // 미낙찰자 알림 이벤트
         }
-    }
-
-    public Page<UserAuctionResponse> getAuctionListByUserId(Long userId, Pageable pageable) {
-        return auctionRepository.findAuctionsByUserId(userId, pageable);
     }
 }

--- a/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
@@ -43,12 +43,12 @@ public class PaymentService {
         if (auction.getWinnerId() == null || !userId.equals(auction.getWinnerId())) {
             throw new AuctionException(AuctionErrorCode.NOT_WINNER);
         }
-        savaPayment(user, tossPaymentResponse, auction);
+        savePayment(user, tossPaymentResponse, auction);
         return ApprovalResponse.of(tossPaymentResponse);
     }
 
     @Transactional
-    public void savaPayment(User payer, TossPaymentResponse tossPaymentResponse, Auction auction) {
+    public void savePayment(User payer, TossPaymentResponse tossPaymentResponse, Auction auction) {
         Payment payment = Payment.of(payer, tossPaymentResponse, auction);
         paymentRepository.save(payment);
     }

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -3,24 +3,33 @@ package org.chzz.market.domain.auction.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.chzz.market.domain.auction.type.AuctionStatus.ENDED;
 import static org.chzz.market.domain.auction.type.AuctionStatus.PROCEEDING;
+import static org.chzz.market.domain.payment.entity.Status.DONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.chzz.market.common.DatabaseTest;
 import org.chzz.market.domain.auction.dto.BaseAuctionDto;
 import org.chzz.market.domain.auction.dto.response.AuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.AuctionResponse;
 import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.bid.repository.BidRepository;
 import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.repository.ImageRepository;
+import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
+import org.chzz.market.domain.payment.entity.Payment;
+import org.chzz.market.domain.payment.entity.Payment.PaymentMethod;
+import org.chzz.market.domain.payment.repository.PaymentRepository;
 import org.chzz.market.domain.product.entity.Product;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.chzz.market.domain.product.repository.ProductRepository;
@@ -47,8 +56,8 @@ class AuctionRepositoryCustomImplTest {
     AuctionRepository auctionRepository;
 
     private static User user1, user2, user3, user4;
-    private static Product product1, product2, product3, product4, product5, product6, product7, product8;
-    private static Auction auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8;
+    private static Product product1, product2, product3, product4, product5, product6, product7, product8, product9;
+    private static Auction auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9;
 
     private static Image image1, image2, image3, image4, image5, image6;
     private static Bid bid1, bid2, bid3, bid4, bid5, bid6, bid7, bid8, bid9, bid10, bid11, bid12, bid13, bid14;
@@ -58,7 +67,8 @@ class AuctionRepositoryCustomImplTest {
                           @Autowired ProductRepository productRepository,
                           @Autowired AuctionRepository auctionRepository,
                           @Autowired ImageRepository imageRepository,
-                          @Autowired BidRepository bidRepository) {
+                          @Autowired BidRepository bidRepository,
+                          @Autowired PaymentRepository paymentRepository) {
         user1 = User.builder().providerId("1234").nickname("닉네임1").email("asd@naver.com").build();
         user2 = User.builder().providerId("12345").nickname("닉네임2").email("asd1@naver.com").build();
         user3 = User.builder().providerId("123456").nickname("닉네임3").email("asd12@naver.com").build();
@@ -81,8 +91,10 @@ class AuctionRepositoryCustomImplTest {
                 .build();
         product8 = Product.builder().user(user2).name("제품8").category(Category.OTHER).minPrice(75000)
                 .build();
+        product9 = Product.builder().user(user2).name("제품9").category(Category.OTHER).minPrice(80000).build();
+
         productRepository.saveAll(
-                List.of(product1, product2, product3, product4, product5, product6, product7, product8));
+                List.of(product1, product2, product3, product4, product5, product6, product7, product8, product9));
 
         auction1 = Auction.builder().product(product1).status(PROCEEDING)
                 .endDateTime(LocalDateTime.now().plusDays(1)).build();
@@ -100,8 +112,23 @@ class AuctionRepositoryCustomImplTest {
                 .endDateTime(LocalDateTime.now().plusSeconds(700)).build();
         auction8 = Auction.builder().product(product8).status(ENDED).winnerId(user4.getId())
                 .endDateTime(LocalDateTime.now().minusDays(1)).build();
+        // auction9 생성 (종료되었지만 낙찰자가 없는 경매)
+        auction9 = Auction.builder()
+                .product(product9)
+                .status(ENDED)
+                .endDateTime(LocalDateTime.now().minusDays(1))
+                .build();
         auctionRepository.saveAll(
-                List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8));
+                List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9));
+
+        // auction8에 대한 결제 데이터 추가 (결제 완료된 경매)
+        TossPaymentResponse tossPaymentResponse = new TossPaymentResponse();
+        tossPaymentResponse.setTotalAmount(250000L);
+        tossPaymentResponse.setMethod(PaymentMethod.CARD);
+        tossPaymentResponse.setStatus(DONE);
+        tossPaymentResponse.setOrderId("order_" + auction8.getId());
+        tossPaymentResponse.setPaymentKey("paymentKey_" + auction8.getId());
+        paymentRepository.save(Payment.of(user4, tossPaymentResponse, auction8));
 
         image1 = Image.builder().product(product1).cdnPath("path/to/image1_1.jpg").sequence(1).build();
         image2 = Image.builder().product(product1).cdnPath("path/to/image1_2.jpg").sequence(2).build();
@@ -627,4 +654,70 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.getContent().get(0).getProductName()).isIn("제품1", "제품2");
         assertThat(result.getContent().get(1).getStatus()).isEqualTo(PROCEEDING);
     }
+
+    @Test
+    @DisplayName("사용자의 종료된 경매 목록 조회")
+    void testFindEndedAuctionByUserId() {
+        // given
+        Long userId = user2.getId(); // user2이 판매자로 등록한 경매를 조회
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UserEndedAuctionResponse> result = auctionRepository.findEndedAuctionByUserId(userId, pageable);
+
+        // then
+        assertNotNull(result);
+        assertThat(result.getContent()).isNotEmpty();
+        assertThat(result.getContent()).hasSize(3); // user2의 종료된 경매는 2개
+    }
+
+    @Test
+    @DisplayName("사용자의 종료된 경매 목록 조회 - 다양한 상황 처리")
+    void testFindEndedAuctionByUserId_MultipleScenarios() {
+        // given
+        Long userId = user2.getId(); // user2의 종료된 경매 조회
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UserEndedAuctionResponse> result = auctionRepository.findEndedAuctionByUserId(userId, pageable);
+
+        // then
+        assertNotNull(result);
+        List<UserEndedAuctionResponse> content = result.getContent();
+
+        // 총 3개의 종료된 경매가 있어야 함 (auction4, auction8, auction9)
+        assertThat(content).hasSize(3);
+
+        // 각각의 경매를 확인하기 위해 맵으로 변환
+        Map<Long, UserEndedAuctionResponse> auctionResponseMap = content.stream()
+                .collect(Collectors.toMap(UserEndedAuctionResponse::auctionId, Function.identity()));
+
+        // auction4 검증 (결제 전 낙찰자 있음)
+        UserEndedAuctionResponse auction4Response = auctionResponseMap.get(auction4.getId());
+        assertNotNull(auction4Response);
+        assertThat(auction4Response.productName()).isEqualTo("제품4");
+        assertThat(auction4Response.winningBidAmount()).isEqualTo(25000L); // 최고 입찰가
+        assertThat(auction4Response.isWon()).isTrue();
+        assertThat(auction4Response.isPaid()).isFalse(); // 결제 전
+        assertThat(auction4Response.participantCount()).isEqualTo(2); // bid11, bid12
+
+        // auction8 검증 (결제 후 낙찰자 있음)
+        UserEndedAuctionResponse auction8Response = auctionResponseMap.get(auction8.getId());
+        assertNotNull(auction8Response);
+        assertThat(auction8Response.productName()).isEqualTo("제품8");
+        assertThat(auction8Response.winningBidAmount()).isEqualTo(250000L); // 최고 입찰가
+        assertThat(auction8Response.isWon()).isTrue();
+        assertThat(auction8Response.isPaid()).isTrue(); // 결제 완료
+        assertThat(auction8Response.participantCount()).isEqualTo(2); // bid13, bid14
+
+        // auction9 검증 (낙찰자 없음)
+        UserEndedAuctionResponse auction9Response = auctionResponseMap.get(auction9.getId());
+        assertNotNull(auction9Response);
+        assertThat(auction9Response.productName()).isEqualTo("제품9");
+        assertThat(auction9Response.winningBidAmount()).isEqualTo(0L); // 입찰 없음
+        assertThat(auction9Response.isWon()).isFalse();
+        assertThat(auction9Response.isPaid()).isFalse(); // 결제 없음
+        assertThat(auction9Response.participantCount()).isEqualTo(0); // 입찰 없음
+    }
+
 }

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -610,4 +610,21 @@ class AuctionRepositoryCustomImplTest {
             assertThat(counts.failedAuctionCount()).isEqualTo(2);
         }
     }
+
+    @Test
+    @DisplayName("사용자의 진행 중인 경매 목록 조회")
+    void testFindProceedingAuctionByUserId() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<UserAuctionResponse> result = auctionRepository.findProceedingAuctionByUserId(user1.getId(), pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2); // user1이 진행 중인 경매는 2개
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo(PROCEEDING);
+        assertThat(result.getContent().get(0).getProductName()).isIn("제품1", "제품2");
+        assertThat(result.getContent().get(1).getStatus()).isEqualTo(PROCEEDING);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-143]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 종료된 내가 등록한 경매 API 추가했습니다.
- 진행중인 내가 등록한 경매 API 추가했습니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

![스크린샷 2024-10-16 오전 4 22 52](https://github.com/user-attachments/assets/ef92bc0a-5d90-4fc1-8dd4-671df3e6771a)


## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 하나의 API로 처리하려다가 첫번째 API는 낙찰유무, 결제유무, 낙찰금액 의 필드가 추가되서 복잡성을 고려하여 분리하였습니다.
- 내가 등록한 종료된 경매 쿼리에서 결제 상태가 DONE으로 하는게 맞는지 확인해주세요 @YeaChan05 


[CHZZ-143]: https://chzz-market.atlassian.net/browse/CHZZ-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ