### PR TITLE
refactor: 나의 입찰 목록 조회 API 동적쿼리로 수정

### DIFF
--- a/.github/workflows/pr-title-and-branch-validation.yml
+++ b/.github/workflows/pr-title-and-branch-validation.yml
@@ -37,7 +37,7 @@ jobs:
           BRANCH_NAME="${{ github.head_ref }}"
           
           # PR 브랜치 이름 검사
-          if [[ "$BRANCH_NAME" =~ ^(feat|fix|docs|refactor|style|test|chore|design|move)/.+$ ]]; then
+          if [[ "$BRANCH_NAME" =~ ^feat/.+$ ]]; then
             echo "✅ Branch name follows the feature branch convention!"
           elif [[ "$BRANCH_NAME" =~ ^(release|hotfix)/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "✅ Branch name follows the release or hotfix versioning convention!"

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -168,8 +168,8 @@ public class AuctionController {
      */
     @PostMapping("/test")
     public ResponseEntity<?> testEndAuction(@LoginUser Long userId,
-                                            @RequestParam("minutes") int minutes) {
-        testService.test(userId, minutes);
+                                            @RequestParam("seconds") int seconds) {
+        testService.test(userId, seconds);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -75,14 +75,6 @@ public class AuctionController {
     }
 
     /**
-     * 경매 입찰 내역 조회
-     */
-    @GetMapping("/history")
-    public ResponseEntity<?> getAuctionHistory(@LoginUser Long userId, Pageable pageable) {
-        return ResponseEntity.ok(auctionService.getAuctionHistory(userId, pageable));
-    }
-
-    /**
      * 내가 성공한 경매 조회
      */
     @GetMapping("/won")

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import org.chzz.market.domain.auction.type.AuctionStatus;
+import org.chzz.market.domain.image.dto.ImageResponse;
 import org.chzz.market.domain.product.entity.Product.Category;
 
 @Getter
@@ -25,7 +26,7 @@ public class AuctionDetailsResponse {
     private final Long bidAmount;
     private final int remainingBidCount;
     private final Boolean isCancelled;
-    private List<String> imageUrls = new ArrayList<>();
+    private List<ImageResponse> images = new ArrayList<>();
 
     @QueryProjection
     public AuctionDetailsResponse(Long productId, String sellerNickname, String sellerProfileImageUrl,
@@ -52,7 +53,7 @@ public class AuctionDetailsResponse {
         this.isCancelled = isCancelled;
     }
 
-    public void addImageList(List<String> imageList) {
-        this.imageUrls = imageList;
+    public void addImageList(List<ImageResponse> images) {
+        this.images = images;
     }
 }

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -24,6 +24,7 @@ public class AuctionDetailsResponse {
     private final Long bidId;
     private final Long bidAmount;
     private final int remainingBidCount;
+    private final Boolean isCancelled;
     private List<String> imageUrls = new ArrayList<>();
 
     @QueryProjection
@@ -32,7 +33,7 @@ public class AuctionDetailsResponse {
                                   Integer minPrice, Category category, Long timeRemaining, AuctionStatus status,
                                   Boolean isSeller,
                                   Long participantCount, Boolean isParticipated, Long bidId, Long bidAmount,
-                                  int remainingBidCount) {
+                                  int remainingBidCount, Boolean isCancelled) {
         this.productId = productId;
         this.sellerNickname = sellerNickname;
         this.sellerProfileImageUrl = sellerProfileImageUrl;
@@ -48,6 +49,7 @@ public class AuctionDetailsResponse {
         this.bidId = bidId;
         this.bidAmount = bidAmount;
         this.remainingBidCount = remainingBidCount;
+        this.isCancelled = isCancelled;
     }
 
     public void addImageList(List<String> imageList) {

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/StartAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/StartAuctionResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
  * 경매 시작 (사전 등록 -> 경매 등록 전환) DTO
  */
 public record StartAuctionResponse(
-        Long auctionId,
+        Long auctionId, // 사전 경매 전환 시 응답 값에 auctionId 사용
         Long productId,
         AuctionStatus status,
         LocalDateTime endDateTime,

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
@@ -21,14 +21,6 @@ public interface AuctionRepositoryCustom {
     Page<AuctionResponse> findAuctionsByCategory(Category category, Long userId, Pageable pageable);
 
     /**
-     * 사용자가 참여한(입찰한) 경매 상세 정보를 조회합니다.
-     * @param userId - 사용자 ID
-     * @param pageable - 페이징 정보
-     * @return - 페이징된 경매 응답 리스트
-     */
-    Page<AuctionResponse> findParticipatingAuctionRecord(Long userId, Pageable pageable);
-
-    /**
      * 경매 ID와 사용자 ID로 경매 상세 정보를 조회합니다.
      *
      * @param auctionId 경매 ID

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -49,6 +49,8 @@ import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.bid.entity.QBid;
+import org.chzz.market.domain.image.dto.ImageResponse;
+import org.chzz.market.domain.image.dto.QImageResponse;
 import org.chzz.market.domain.image.entity.QImage;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.chzz.market.domain.user.dto.response.ParticipationCountsResponse;
@@ -143,7 +145,8 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                 .where(auction.id.eq(auctionId))
                 .fetchOne());
 
-        auctionDetailsResponse.ifPresent(response -> response.addImageList(getImageList(response.getProductId())));
+        auctionDetailsResponse.ifPresent(
+                response -> response.addImageList(getImagesByProductId(response.getProductId())));
 
         return auctionDetailsResponse;
     }
@@ -535,12 +538,10 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
 
     /**
      * 상품의 이미지 리스트를 조회합니다.
-     *
-     * @param productId 상품 ID
-     * @return 이미지 경로 리스트
      */
-    private List<String> getImageList(Long productId) {
-        return jpaQueryFactory.select(image.cdnPath)
+    private List<ImageResponse> getImagesByProductId(Long productId) {
+        return jpaQueryFactory
+                .select(new QImageResponse(image.id, image.cdnPath))
                 .from(image)
                 .where(image.product.id.eq(productId))
                 .orderBy(image.sequence.asc())

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -95,40 +95,6 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
     }
 
     /**
-     * 사용자의 경매 참여 기록을 조회합니다
-     *
-     * @param userId   사용자 ID
-     * @param pageable 페이징 정보
-     * @return 회원의 경매 참여 기록
-     */
-    @Override
-    public Page<AuctionResponse> findParticipatingAuctionRecord(Long userId, Pageable pageable) {
-        JPAQuery<?> baseQuery = getActualParticipatedAuction(userId)
-                .join(auction.product, product);
-
-        List<AuctionResponse> content = baseQuery
-                .select(new QAuctionResponse(
-                        auction.id,
-                        product.name,
-                        image.cdnPath,
-                        timeRemaining().longValue(),
-                        auction.product.minPrice.longValue(),
-                        getBidCount()
-                ))
-                .leftJoin(image).on(image.product.id.eq(product.id).and(image.id.eq(getFirstImageId())))
-                .where(auction.status.eq(PROCEEDING).and(auction.endDateTime.after(LocalDateTime.now())))
-                .groupBy(auction.id, product.name, image.cdnPath)
-                .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        JPAQuery<Long> countQuery = baseQuery
-                .select(auction.id.countDistinct());
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
-    }
-
-    /**
      * 경매 ID와 사용자 ID로 경매 상세 정보를 조회합니다.
      *
      * @param auctionId 경매 ID

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -93,13 +93,6 @@ public class AuctionService {
     }
 
     /**
-     * 사용자가 참여한(입찰한) 경매 상세 정보를 조회
-     */
-    public Page<AuctionResponse> getAuctionHistory(Long userId, Pageable pageable) {
-        return auctionRepository.findParticipatingAuctionRecord(userId, pageable);
-    }
-
-    /**
      * 내가 성공한 경매 조회
      */
     public Page<WonAuctionResponse> getWonAuctionHistory(Long userId, Pageable pageable) {

--- a/src/main/java/org/chzz/market/domain/auction/type/TestService.java
+++ b/src/main/java/org/chzz/market/domain/auction/type/TestService.java
@@ -28,7 +28,7 @@ public class TestService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void test(Long userId, int minutes) {
+    public void test(Long userId, int seconds) {
         Random random = new Random();
         int randomIndex = random.nextInt(1000) + 1;  // 1부터 1000까지 랜덤 숫자 생성
         int randomIndex1 = random.nextInt(1000) + 1;  // 1부터 1000까지 랜덤 숫자 생성
@@ -58,7 +58,7 @@ public class TestService {
         product.addImages(List.of(image1, image2));
         auctionRepository.save(Auction.builder()
                 .status(AuctionStatus.PROCEEDING)
-                .endDateTime(LocalDateTime.now().plusMinutes(minutes))
+                .endDateTime(LocalDateTime.now().plusSeconds(seconds))
                 .product(product)
                 .build());
     }

--- a/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
+++ b/src/main/java/org/chzz/market/domain/bid/controller/BidController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.config.LoginUser;
+import org.chzz.market.domain.auction.type.AuctionStatus;
 import org.chzz.market.domain.bid.dto.BidCreateRequest;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.service.BidService;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,14 +29,19 @@ public class BidController {
     private final BidService bidService;
 
     /**
-     * 입찰 내역 조회
+     * 나의 입찰 목록 조회
+     *
+     * @param status 경매 상태 필터링 파라미터
+     *                - 전체 조회: 값이 없거나 null인 경우
+     *                - 진행 중인 경매의 입찰만 조회: 'proceeding' 값을 사용할 때
+     *                - 종료된 경매의 입찰만 조회: 'ended' 값을 사용할 때
      */
     @GetMapping
     public ResponseEntity<?> findUsersBidHistory(
             @LoginUser Long userId,
-            @PageableDefault
-            Pageable pageable) {
-        Page<BiddingRecord> records = bidService.inquireBidHistory(userId, pageable);
+            @PageableDefault(sort = "time-remaining") Pageable pageable,
+            @RequestParam(value = "status", required = false) AuctionStatus status) {
+        Page<BiddingRecord> records = bidService.inquireBidHistory(userId, pageable, status);
         return ResponseEntity.ok(records);
     }
 

--- a/src/main/java/org/chzz/market/domain/bid/dto/query/BiddingRecord.java
+++ b/src/main/java/org/chzz/market/domain/bid/dto/query/BiddingRecord.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 import org.chzz.market.domain.auction.dto.BaseAuctionDto;
 @Getter
 public class BiddingRecord extends BaseAuctionDto {
+    private final Long auctionId;
     private final Long bidAmount;
 
     @QueryProjection
-    public BiddingRecord(String productName, Long minPrice, Long bidAmount, Long participantCount, String cdnPath,
+    public BiddingRecord(Long auctionId, String productName, Long minPrice, Long bidAmount, Long participantCount, String cdnPath,
                          Long timeRemaining) {
         super(productName, cdnPath, timeRemaining, minPrice, participantCount);
+        this.auctionId = auctionId;
         this.bidAmount = bidAmount;
     }
 }

--- a/src/main/java/org/chzz/market/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/bid/repository/BidRepositoryCustom.java
@@ -2,6 +2,7 @@ package org.chzz.market.domain.bid.repository;
 
 import java.util.List;
 import org.chzz.market.domain.auction.entity.Auction;
+import org.chzz.market.domain.auction.type.AuctionStatus;
 import org.chzz.market.domain.bid.dto.query.BiddingRecord;
 import org.chzz.market.domain.bid.dto.response.BidInfoResponse;
 import org.chzz.market.domain.bid.entity.Bid;
@@ -9,7 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BidRepositoryCustom {
-    Page<BiddingRecord> findUsersBidHistory(Long userId, Pageable pageable);
+    Page<BiddingRecord> findUsersBidHistory(Long userId, Pageable pageable, AuctionStatus status);
 
     List<Bid> findAllBidsByAuction(Auction auction);
 

--- a/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -107,16 +107,9 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 .where(auction.id.isNull().and(product.id.eq(productId)))
                 .fetchOne());
 
-        return result.map(response -> {
-            List<ImageResponse> images = jpaQueryFactory
-                    .select(new QImageResponse(image.id, image.cdnPath))
-                    .from(image)
-                    .where(image.product.id.eq(productId))
-                    .orderBy(image.sequence.asc())
-                    .fetch();
-            response.addImageList(images);
-            return response;
-        });
+        // 이미지 목록 추가
+        result.ifPresent(response -> response.addImageList(getImagesByProductId(productId)));
+        return result;
     }
 
     /**
@@ -216,6 +209,18 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 .fetchJoin()
                 .where(product.id.eq(productId))
                 .fetchOne());
+    }
+
+    /**
+     * 제품의 이미지 리스트를 조회
+     */
+    private List<ImageResponse> getImagesByProductId(Long productId) {
+        return jpaQueryFactory
+                .select(new QImageResponse(image.id, image.cdnPath))
+                .from(image)
+                .where(image.product.id.eq(productId))
+                .orderBy(image.sequence.asc())
+                .fetch();
     }
 
     private JPQLQuery<Long> getFirstImageId() {

--- a/src/main/resources/db/migration/V6__add_index_on_product.sql
+++ b/src/main/resources/db/migration/V6__add_index_on_product.sql
@@ -1,7 +1,0 @@
--- 파일명: V6__add_index_on_product.sql
--- 파일 설명: product index 추가
--- 작성일: 2024-10-18
--- 참고: 이 파일은 Flyway 명명 규칙 "V<버전번호>__<설명>.sql"을 따릅니다.
---      적용된 후에는 절대 수정할 수 없으므로, 수정이 필요한 경우에는 새로운 마이그레이션 파일을 작성해 주세요.
-
-CREATE INDEX idx_product_id_name ON product (product_id, name);

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -86,7 +86,7 @@ class AuctionRepositoryCustomImplTest {
         product9 = Product.builder().user(user3).name("제품9").category(Category.OTHER).minPrice(75000)
                 .build();
         productRepository.saveAll(
-                List.of(product1, product2, product3, product4, product5, product6, product7, product8 ,product9));
+                List.of(product1, product2, product3, product4, product5, product6, product7, product8, product9));
 
         auction1 = Auction.builder().product(product1).status(PROCEEDING)
                 .endDateTime(LocalDateTime.now().plusDays(1)).build();
@@ -130,9 +130,7 @@ class AuctionRepositoryCustomImplTest {
         bid12 = Bid.builder().bidder(user3).auction(auction4).amount(25000L).build();
         bid13 = Bid.builder().bidder(user4).auction(auction8).amount(250000L).build();
         bid14 = Bid.builder().bidder(user2).auction(auction8).amount(150000L).build();
-        bid15 = Bid.builder().bidder(user5).auction(auction9).amount(50000L).status(BidStatus.CANCELLED).build();
-        bidRepository.saveAll(List.of(bid1, bid2, bid3, bid4, bid5, bid6, bid7, bid8, bid10, bid11, bid12, bid13,
-                bid14, bid15));
+        bid15 = Bid.builder().bidder(user5).auction(auction9).amount(75000L).status(BidStatus.ACTIVE).build();
 
         auction1.registerBid(bid1);
         auction2.registerBid(bid2);
@@ -148,6 +146,9 @@ class AuctionRepositoryCustomImplTest {
         auction8.registerBid(bid13);
         auction8.registerBid(bid14);
         auction9.registerBid(bid15);
+        auction9.removeBid(bid15);
+        bidRepository.saveAll(List.of(bid1, bid2, bid3, bid4, bid5, bid6, bid7, bid8, bid10, bid11, bid12, bid13,
+                bid14, bid15));
     }
 
     @Test
@@ -368,7 +369,6 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.getContent().get(0).getCreatedAt()).isBefore(result.getContent().get(1).getCreatedAt());
     }
 
-
     @Test
     @DisplayName("나의 경매 목록 조회했는데 없는 경우")
     public void testFindMyAuctionsNotExist() throws Exception {
@@ -384,17 +384,17 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.getContent()).hasSize(0);
     }
 
-    @Test
-    @DisplayName("베스트 경매 조회")
-    void testFindBestAuctions() {
-        // given
-        List<AuctionResponse> bestAuctions = auctionRepository.findBestAuctions();
-        // when
-
-        // then
-        assertThat(bestAuctions).isSortedAccordingTo(
-                Comparator.comparingLong(AuctionResponse::getParticipantCount).reversed());
-    }
+//    @Test
+//    @DisplayName("베스트 경매 조회")
+//    void testFindBestAuctions() {
+//        // given
+//        List<AuctionResponse> bestAuctions = auctionRepository.findBestAuctions();
+//        // when
+//
+//        // then
+//        assertThat(bestAuctions).isSortedAccordingTo(
+//                Comparator.comparingLong(AuctionResponse::getParticipantCount).reversed());
+//    }
 
     @Test
     @DisplayName("마감 임박 경매 조회")

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -25,6 +25,7 @@ import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.bid.entity.Bid.BidStatus;
 import org.chzz.market.domain.bid.repository.BidRepository;
+import org.chzz.market.domain.image.dto.ImageResponse;
 import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.repository.ImageRepository;
 import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
@@ -258,7 +259,10 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.get().getBidAmount()).isEqualTo(0);
         assertThat(result.get().getIsParticipated()).isFalse();
         assertThat(result.get().getBidId()).isNull();
-        assertThat(result.get().getImageUrls()).containsOnly(image1.getCdnPath(), image2.getCdnPath());
+        assertThat(result.get().getImages())
+                .hasSize(2)
+                .extracting(ImageResponse::imageUrl)
+                .containsExactlyInAnyOrder(image1.getCdnPath(), image2.getCdnPath());
         assertThat(result.get().getIsCancelled()).isFalse();
     }
 
@@ -306,7 +310,10 @@ class AuctionRepositoryCustomImplTest {
         assertThat(response.getBidAmount()).isEqualTo(6000L); // user3의 최신 입찰액
         assertThat(response.getBidId()).isNotNull();
         assertThat(response.getParticipantCount()).isGreaterThanOrEqualTo(2); // 최소 2명 (user2, user3)
-        assertThat(response.getImageUrls()).contains("path/to/image2.jpg");
+        assertThat(result.get().getImages())
+                .hasSize(1)
+                .extracting(ImageResponse::imageUrl)
+                .containsExactlyInAnyOrder(image3.getCdnPath());
         assertThat(response.getIsCancelled()).isFalse();
     }
 

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -314,7 +314,7 @@ class AuctionRepositoryCustomImplTest {
     @DisplayName("경매 상세 조회 - 없는 경매인 경우")
     public void testFindAuctionDetailsById_NonExistentAuction() throws Exception {
         //given
-        Long auctionId = 10L;
+        Long auctionId = 100L;
         Long userId = user1.getId();
 
         //when
@@ -413,17 +413,17 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result.getContent()).hasSize(0);
     }
 
-//    @Test
-//    @DisplayName("베스트 경매 조회")
-//    void testFindBestAuctions() {
-//        // given
-//        List<AuctionResponse> bestAuctions = auctionRepository.findBestAuctions();
-//        // when
-//
-//        // then
-//        assertThat(bestAuctions).isSortedAccordingTo(
-//                Comparator.comparingLong(AuctionResponse::getParticipantCount).reversed());
-//    }
+    @Test
+    @DisplayName("베스트 경매 조회")
+    void testFindBestAuctions() {
+        // given
+        List<AuctionResponse> bestAuctions = auctionRepository.findBestAuctions();
+        // when
+
+        // then
+        assertThat(bestAuctions).isSortedAccordingTo(
+                Comparator.comparingLong(AuctionResponse::getParticipantCount).reversed());
+    }
 
     @Test
     @DisplayName("마감 임박 경매 조회")

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -378,60 +378,6 @@ class AuctionRepositoryCustomImplTest {
     }
 
     @Test
-    @DisplayName("내가 참여한 경매 목록 조회 -  가격순")
-    void testFindParticipatingAuctionRecordWithExpensive() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("expensive"));
-        Page<AuctionResponse> responses = auctionRepository.findParticipatingAuctionRecord(user1.getId(), pageable);
-        // when
-
-        // then
-        assertThat(responses.getContent())
-                .isSortedAccordingTo(Comparator.comparingLong(BaseAuctionDto::getMinPrice).reversed());
-        assertThat(responses.getContent())
-                .allMatch(auctionResponse -> {
-                    Auction auction = auctionRepository.findById(auctionResponse.getAuctionId()).get();
-                    return auction.getStatus().equals(PROCEEDING);
-                });
-    }
-
-    @Test
-    @DisplayName("내가 참여한 경매 목록 조회 -  인기순")
-    void testFindParticipatingAuctionRecordWithPopularity() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("popularity"));
-        Page<AuctionResponse> responses = auctionRepository.findParticipatingAuctionRecord(user1.getId(), pageable);
-        // when
-
-        // then
-        assertThat(responses.getContent()).isSortedAccordingTo(
-                Comparator.comparingLong(BaseAuctionDto::getParticipantCount).reversed());
-        assertThat(responses.getContent())
-                .allMatch(auctionResponse -> {
-                    Auction auction = auctionRepository.findById(auctionResponse.getAuctionId()).get();
-                    return auction.getStatus().equals(PROCEEDING);
-                });
-    }
-
-    @Test
-    @DisplayName("내가 참여한 경매 목록 조회 -  남은 시간순")
-    void testFindParticipatingAuctionRecordWithTime() {
-        // given
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("newest"));
-        Page<AuctionResponse> responses = auctionRepository.findParticipatingAuctionRecord(user1.getId(), pageable);
-        // when
-
-        // then
-        assertThat(responses.getContent()).isSortedAccordingTo(
-                Comparator.comparingLong(BaseAuctionDto::getTimeRemaining));
-        assertThat(responses.getContent())
-                .allMatch(auctionResponse -> {
-                    Auction auction = auctionRepository.findById(auctionResponse.getAuctionId()).get();
-                    return auction.getStatus().equals(PROCEEDING);
-                });
-    }
-
-    @Test
     @DisplayName("사용자의 실패한 경매 조회")
     void testGetLostAuctionHistory() {
         // given

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -355,7 +355,7 @@ class AuctionServiceTest {
             Long existingAuctionId = 1L;
             Long userId = 1L;
             AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(1L, "닉네임2", "null", "제품1", null, 1000,
-                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0);
+                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false);
 
             // when
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(

--- a/src/test/java/org/chzz/market/domain/bid/repository/BidRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/bid/repository/BidRepositoryCustomImplTest.java
@@ -204,8 +204,8 @@ class BidRepositoryCustomImplTest {
     void testFindBidHistory() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by("bidAmount"));
-        Page<BiddingRecord> usersBidHistory1 = bidRepository.findUsersBidHistory(bidder1.getId(), pageable);
-        Page<BiddingRecord> usersBidHistory2 = bidRepository.findUsersBidHistory(bidder2.getId(), pageable);
+        Page<BiddingRecord> usersBidHistory1 = bidRepository.findUsersBidHistory(bidder1.getId(), pageable, null);
+        Page<BiddingRecord> usersBidHistory2 = bidRepository.findUsersBidHistory(bidder2.getId(), pageable, null);
 
         // when
 
@@ -228,8 +228,8 @@ class BidRepositoryCustomImplTest {
     void testFindBidHistoryOrderByTimeRemaining() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by("time-remaining"));
-        Page<BiddingRecord> usersBidHistory1 = bidRepository.findUsersBidHistory(bidder1.getId(), pageable);
-        Page<BiddingRecord> usersBidHistory2 = bidRepository.findUsersBidHistory(bidder2.getId(), pageable);
+        Page<BiddingRecord> usersBidHistory1 = bidRepository.findUsersBidHistory(bidder1.getId(), pageable, null);
+        Page<BiddingRecord> usersBidHistory2 = bidRepository.findUsersBidHistory(bidder2.getId(), pageable, null);
         // when
 
         // then


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-144]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- /auctions/history 와 /bids API가 중복된 API여서 auctions/history를 삭제하였습니다.
- bids API에 동적쿼리를 적용하여 현재는 진행중인 입찰목록 조회 API만을 필요로 하지만, 확장성을 위해 동적쿼리로 수정하였습니다.
- 파라미터가 안들어오면 전체 목록조회입니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->



[CHZZ-144]: https://chzz-market.atlassian.net/browse/CHZZ-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ