### PR TITLE
fix: SSE 에러처리 버그 수정

### DIFF
--- a/src/main/java/org/chzz/market/common/config/SecurityConfig.java
+++ b/src/main/java/org/chzz/market/common/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                                 "/api/v1/products/categories",
                                 "/api/v1/products/{productId:\\d+}",
                                 "/api/v1/products/users/*",
+                                "/api/v1/notifications/subscribe",
                                 "/api/v1/users/*",
                                 "/api/v1/users/check/nickname/*").permitAll()
                         .requestMatchers(POST,

--- a/src/main/java/org/chzz/market/common/error/GlobalErrorCode.java
+++ b/src/main/java/org/chzz/market/common/error/GlobalErrorCode.java
@@ -13,7 +13,7 @@ public enum GlobalErrorCode implements ErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "Validation failed"),
     AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "Authentication is required"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access is denied"),
-    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST,"Unsupported type of sort" ),
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "Unsupported type of sort"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
     EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "external api error. check server log.");

--- a/src/main/java/org/chzz/market/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/chzz/market/common/error/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.chzz.market.common.error.handler;
 
 import static org.chzz.market.common.error.GlobalErrorCode.EXTERNAL_API_ERROR;
 
+import java.io.IOException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.chzz.market.common.error.ErrorCode;
@@ -31,7 +32,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final String LOG_FORMAT = "\nException Class = {}\nResponse Code = {}\nMessage = {}";
 
     // 1. 커스텀 예외 핸들러
-
     /**
      * 비즈니스 로직에서 정의한 예외가 발생할 때 처리
      */
@@ -71,8 +71,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
-    // 2. ResponseEntityExceptionHandler에서 오버라이드된 핸들러
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<Object> handleIOException(IOException e) {
+        if (e.getMessage().contains("Broken pipe")) {
+            return null; // 연결이 끊어진 경우 응답을 하지 않음
+        } else {
+            GlobalErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+            logException(e, errorCode);
+            return handleExceptionInternal(errorCode);
+        }
+    }
 
+    // 2. ResponseEntityExceptionHandler에서 오버라이드된 핸들러
     /**
      * 필수 요청 매개변수가 누락된 경우 발생
      */

--- a/src/main/java/org/chzz/market/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/chzz/market/domain/notification/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package org.chzz.market.domain.notification.controller;
 
+import static org.chzz.market.common.error.GlobalErrorCode.AUTHENTICATION_REQUIRED;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.chzz.market.common.config.LoginUser;
+import org.chzz.market.common.error.GlobalException;
 import org.chzz.market.domain.notification.service.NotificationService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +31,9 @@ public class NotificationController {
 
     @GetMapping(value = "/subscribe", produces = TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@LoginUser Long userId, HttpServletResponse response) {
+        if (userId == null) {
+            throw new GlobalException(AUTHENTICATION_REQUIRED);
+        }
         response.setHeader("X-Accel-Buffering", "no");
         return notificationService.subscribe(userId);
     }

--- a/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
@@ -59,7 +59,8 @@ public class NotificationService {
                         .data(objectMapper.writeValueAsString(sseResponse)));
                 log.info("SSE 전송: userId: {}, sseResponse: {}", userId, sseResponse);
             } catch (IOException e) {
-                log.error("Error sending SSE event to user {}", userId);
+                // 내부에서 추가로 IOException이 발생하므로, 프레임워크의 예외 처리 핸들러에 처리
+                log.info("사용자 ID {}의 SSE 끊어진 연결을 정리합니다.", userId);
             }
         });
     }
@@ -92,12 +93,7 @@ public class NotificationService {
             log.info("SSE connection completed for user {}", userId);
         });
         emitter.onTimeout(() -> {
-            emitter.complete();
             log.info("SSE connection timed out for user {}", userId);
-        });
-        emitter.onError((e) -> {
-            emitter.complete();
-            log.error("SSE connection error for user {}", userId);
         });
     }
 

--- a/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
@@ -60,7 +60,7 @@ public class NotificationService {
                 log.info("SSE 전송: userId: {}, sseResponse: {}", userId, sseResponse);
             } catch (IOException e) {
                 // 내부에서 추가로 IOException이 발생하므로, 프레임워크의 예외 처리 핸들러에 처리
-                log.info("사용자 ID {}의 SSE 끊어진 연결을 정리합니다.", userId);
+                log.info("사용자 ID {}의 끊어진 SSE 연결을 정리합니다.", userId);
             }
         });
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-145]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- SSE 에러 콜백 메서드와 예외 핸들러를 변경해 에러로그 찍히는걸 처리하였습니다.
- 해당 연결을 완료처리 할 때 인증이 필요한 API여서 해당 API를 security에서 인증허용하고, 컨트롤러에서 인증 체크 하였습니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- SSE연결을 하고 클라이언트에서 브라우저를 끄거나 연결 끊을시
![스크린샷 2024-10-17 오후 9 59 01](https://github.com/user-attachments/assets/83551c75-226a-4797-8134-0117738c0e00)

- SSE 타임아웃 시 (해당 연결 정리 후 클라이언트에서 재연결 요청 후 재연결)
![스크린샷 2024-10-17 오후 10 06 09](https://github.com/user-attachments/assets/3f4a78f5-4530-4b92-8041-0ff318b5f5cb)


## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->


[CHZZ-145]: https://chzz-market.atlassian.net/browse/CHZZ-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ