### PR TITLE
refactor: 인기순 정렬 조건 수정

### DIFF
--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -478,11 +478,11 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
      *
      * @return 참여자 수
      */
-    private JPQLQuery<Long> getBidCount() {
-        return JPAExpressions
+    private static NumberExpression<Long> getBidCount() {
+        return Expressions.asNumber(JPAExpressions
                 .select(bid.count())
                 .from(bid)
-                .where(bid.auction.id.eq(auction.id).and(bid.status.eq(ACTIVE)));
+                .where(bid.auction.id.eq(auction.id).and(bid.status.eq(ACTIVE))));
     }
 
     /**
@@ -515,7 +515,7 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public enum AuctionOrder implements QuerydslOrder {
-        POPULARITY("popularity", auction.bids.size().desc()),
+        POPULARITY("popularity", getBidCount().desc()),
         EXPENSIVE("expensive", product.minPrice.desc()),
         CHEAP("cheap", product.minPrice.asc()),
         NEWEST("newest", auction.createdAt.desc());

--- a/src/main/java/org/chzz/market/domain/product/entity/Product.java
+++ b/src/main/java/org/chzz/market/domain/product/entity/Product.java
@@ -38,7 +38,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Builder
 @Table(indexes = {
-        @Index(name = "idx_product_id_name", columnList = "product_id, productName")
+        @Index(name = "idx_product_id_name", columnList = "product_id, name")
 })
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,15 +12,10 @@ spring:
     username: sa
     password:
 
-    h2:
-      console:
-        enabled: true
-    jpa:
-      hibernate:
-        ddl-auto: create
-      properties:
-        hibernate:
-          dialect: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/src/main/resources/db/migration/V6__add_index_on_product.sql
+++ b/src/main/resources/db/migration/V6__add_index_on_product.sql
@@ -1,0 +1,7 @@
+-- 파일명: V6__add_index_on_product.sql
+-- 파일 설명: product index 추가
+-- 작성일: 2024-10-18
+-- 참고: 이 파일은 Flyway 명명 규칙 "V<버전번호>__<설명>.sql"을 따릅니다.
+--      적용된 후에는 절대 수정할 수 없으므로, 수정이 필요한 경우에는 새로운 마이그레이션 파일을 작성해 주세요.
+
+CREATE INDEX idx_product_id_name ON product (product_id, name);

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -18,6 +18,7 @@ import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
+import org.chzz.market.domain.bid.entity.Bid.BidStatus;
 import org.chzz.market.domain.bid.repository.BidRepository;
 import org.chzz.market.domain.image.entity.Image;
 import org.chzz.market.domain.image.repository.ImageRepository;
@@ -111,19 +112,19 @@ class AuctionRepositoryCustomImplTest {
         image6 = Image.builder().product(product8).cdnPath("path/to/image5.jpg").sequence(1).build();
         imageRepository.saveAll(List.of(image1, image2, image3, image4, image5, image6));
 
-        bid1 = Bid.builder().bidder(user2).auction(auction1).amount(2000L).build();
-        bid2 = Bid.builder().bidder(user2).auction(auction2).amount(4000L).build();
-        bid3 = Bid.builder().bidder(user1).auction(auction3).amount(5000L).build();
-        bid4 = Bid.builder().bidder(user3).auction(auction2).amount(6000L).build();
-        bid5 = Bid.builder().bidder(user1).auction(auction5).amount(7000L).build();
-        bid6 = Bid.builder().bidder(user2).auction(auction6).amount(8000L).build();
-        bid7 = Bid.builder().bidder(user3).auction(auction3).amount(310000L).build();
-        bid8 = Bid.builder().bidder(user4).auction(auction3).amount(320000L).build();
-        bid10 = Bid.builder().bidder(user2).auction(auction3).amount(8000L).build();
-        bid11 = Bid.builder().bidder(user2).auction(auction4).amount(15000L).build();
-        bid12 = Bid.builder().bidder(user3).auction(auction4).amount(25000L).build();
-        bid13 = Bid.builder().bidder(user4).auction(auction8).amount(250000L).build();
-        bid14 = Bid.builder().bidder(user2).auction(auction8).amount(150000L).build();
+        bid1 = Bid.builder().bidder(user2).auction(auction1).status(BidStatus.ACTIVE).amount(2000L).build();
+        bid2 = Bid.builder().bidder(user2).auction(auction2).status(BidStatus.ACTIVE).amount(4000L).build();
+        bid3 = Bid.builder().bidder(user1).auction(auction3).status(BidStatus.CANCELLED).amount(5000L).build();
+        bid4 = Bid.builder().bidder(user3).auction(auction2).status(BidStatus.ACTIVE).amount(6000L).build();
+        bid5 = Bid.builder().bidder(user1).auction(auction5).status(BidStatus.ACTIVE).amount(7000L).build();
+        bid6 = Bid.builder().bidder(user2).auction(auction6).status(BidStatus.ACTIVE).amount(8000L).build();
+        bid7 = Bid.builder().bidder(user3).auction(auction3).status(BidStatus.CANCELLED).amount(310000L).build();
+        bid8 = Bid.builder().bidder(user4).auction(auction3).status(BidStatus.CANCELLED).amount(320000L).build();
+        bid10 = Bid.builder().bidder(user2).auction(auction3).status(BidStatus.ACTIVE).amount(8000L).build();
+        bid11 = Bid.builder().bidder(user2).auction(auction4).status(BidStatus.ACTIVE).amount(15000L).build();
+        bid12 = Bid.builder().bidder(user3).auction(auction4).status(BidStatus.ACTIVE).amount(25000L).build();
+        bid13 = Bid.builder().bidder(user4).auction(auction8).status(BidStatus.ACTIVE).amount(250000L).build();
+        bid14 = Bid.builder().bidder(user2).auction(auction8).status(BidStatus.ACTIVE).amount(150000L).build();
         bidRepository.saveAll(List.of(bid1, bid2, bid3, bid4, bid5, bid6, bid7, bid8, bid10, bid11, bid12, bid13,
                 bid14));
 
@@ -156,8 +157,8 @@ class AuctionRepositoryCustomImplTest {
         assertThat(result).isNotNull();
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).getProductName()).isEqualTo("제품3");
-        assertThat(result.getContent().get(0).getIsParticipated()).isTrue();
-        assertThat(result.getContent().get(0).getParticipantCount()).isEqualTo(4);
+        assertThat(result.getContent().get(0).getIsParticipated()).isFalse();
+        assertThat(result.getContent().get(0).getParticipantCount()).isEqualTo(1);
         assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("path/to/image3.jpg");
         assertThat(result.getContent().get(1).getProductName()).isEqualTo("제품1");
         assertThat(result.getContent().get(1).getIsParticipated()).isFalse();
@@ -178,14 +179,15 @@ class AuctionRepositoryCustomImplTest {
         //then
         assertThat(result).isNotNull();
         assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).getProductName()).isEqualTo("제품3");
+        assertThat(result.getContent().get(0).getProductName()).isEqualTo("제품1");
         assertThat(result.getContent().get(0).getIsParticipated()).isTrue();
-        assertThat(result.getContent().get(0).getParticipantCount()).isEqualTo(4);
-        assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("path/to/image3.jpg");
-        assertThat(result.getContent().get(1).getProductName()).isEqualTo("제품1");
+        assertThat(result.getContent().get(0).getParticipantCount()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getImageUrl()).isEqualTo("path/to/image1_1.jpg");
+        assertThat(result.getContent().get(1).getProductName()).isEqualTo("제품3");
         assertThat(result.getContent().get(1).getIsParticipated()).isTrue();
         assertThat(result.getContent().get(1).getParticipantCount()).isEqualTo(1);
-        assertThat(result.getContent().get(1).getImageUrl()).isEqualTo("path/to/image1_1.jpg");
+        assertThat(result.getContent().get(1).getImageUrl()).isEqualTo("path/to/image3.jpg");
+
     }
 
     @Test
@@ -400,9 +402,9 @@ class AuctionRepositoryCustomImplTest {
     void testFindParticipatingAuctionRecordWithPopularity() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by("popularity"));
-        Page<AuctionResponse> responses = auctionRepository.findParticipatingAuctionRecord(user1.getId(), pageable);
+        Page<AuctionResponse> responses = auctionRepository.findParticipatingAuctionRecord(user3.getId(), pageable);
         // when
-
+        responses.getContent().forEach(System.out::println);
         // then
         assertThat(responses.getContent()).isSortedAccordingTo(
                 Comparator.comparingLong(BaseAuctionDto::getParticipantCount).reversed());


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-155]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 인기순 정렬 조건에서 취소된 입찰 제외하여 정렬되도록 수정
- 적용되지 않던 product의 index 적용

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- ![image](https://github.com/user-attachments/assets/c25eb2a9-e1c0-44c5-b4e5-7ff236d64a69)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 테스트가 다소 부실한감이 있습니다
하지만 코드 실행시 정렬 조건을 보고 확신이 있어 pr 올립니다
```SQl
order by (select count(b4_0.bid_id) from bid b4_0 where b4_0.auction_id=a1_0.auction_id and b4_0.status=?)
```


[CHZZ-155]: https://chzz-market.atlassian.net/browse/CHZZ-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ