### PR TITLE
feat: SSE heartbeat 기능 추가

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -80,7 +80,7 @@
              proxy_set_header Connection '';
              proxy_set_header Cache_Control 'no-cache';
              chunked_transfer_encoding on;
-             proxy_read_timeout 1920s; # Nginx가 백엔드 서버로부터 데이터를 받지 못하는 동안 대기할 최대 시간, 이 시간 동안 데이터가 안오면 연결 끊음 (클라이언트에서 재연결 요청)
+             proxy_read_timeout 90s; # Nginx가 백엔드 서버로부터 데이터를 받지 못하는 동안 대기할 최대 시간, 이 시간 동안 데이터가 안오면 연결 끊음 (클라이언트에서 재연결 요청) 서버의 heartbeat 시간보다 조금 길게
          }
      }
  }

--- a/src/main/java/org/chzz/market/common/config/SchedulingConfig.java
+++ b/src/main/java/org/chzz/market/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package org.chzz.market.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/org/chzz/market/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/org/chzz/market/domain/notification/repository/EmitterRepository.java
@@ -1,15 +1,40 @@
 package org.chzz.market.domain.notification.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface EmitterRepository {
+    /**
+     * 주어진 사용자 ID에 해당하는 SSE 이미터 목록을 찾습니다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자의 SSE 이미터 목록이 포함된 Optional 객체. 이미터가 없는 경우 비어있는 Optional을 반환합니다.
+     */
+    Optional<List<SseEmitter>> findByUserId(Long userId);
+
+    /**
+     * 모든 사용자에 대한 SSE 이미터를 반환합니다.
+     *
+     * @return 사용자 ID를 키로 하고, 해당 사용자와 연결된 SSE 이미터 목록을 값으로 하는 맵입니다.
+     */
+    Map<Long, List<SseEmitter>> findAllEmitters();
+
+    /**
+     * 주어진 사용자 ID에 SSE 이미터를 저장합니다.
+     *
+     * @param userId  사용자 ID
+     * @param emitter 저장할 SSE 이미터
+     */
     void save(Long userId, SseEmitter emitter);
 
-    void deleteById(Long userId);
+    /**
+     * 주어진 사용자 ID에 연결된 SSE 이미터를 삭제합니다.
+     *
+     * @param userId  사용자 ID
+     * @param emitter 삭제할 SSE 이미터
+     */
+    void deleteEmitter(Long userId, SseEmitter emitter);
 
-    Optional<SseEmitter> findById(Long userId);
-
-    List<Long> findAllId();
 }

--- a/src/main/java/org/chzz/market/domain/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/org/chzz/market/domain/notification/repository/EmitterRepositoryImpl.java
@@ -1,9 +1,11 @@
 package org.chzz.market.domain.notification.repository;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -11,27 +13,35 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Repository
 @Slf4j
 public class EmitterRepositoryImpl implements EmitterRepository {
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     @Override
-    public void save(Long userId, SseEmitter emitter) {
-        emitters.put(userId, emitter);
-        log.info("Saved SSE Emitter for user {}", userId);
-    }
-
-    @Override
-    public void deleteById(Long userId) {
-        emitters.remove(userId);
-        log.info("Deleted SSE Emitter for user {}", userId);
-    }
-
-    @Override
-    public Optional<SseEmitter> findById(Long userId) {
+    public Optional<List<SseEmitter>> findByUserId(Long userId) {
         return Optional.ofNullable(emitters.get(userId));
     }
 
     @Override
-    public List<Long> findAllId() {
-        return emitters.keySet().stream().toList();
+    public Map<Long, List<SseEmitter>> findAllEmitters() {
+        return Collections.unmodifiableMap(emitters);
     }
+
+    @Override
+    public void save(Long userId, SseEmitter emitter) {
+        emitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        log.info("[SSE] 연결 저장 UserId: {}", userId);
+    }
+
+    @Override
+    public void deleteEmitter(Long userId, SseEmitter emitter) {
+        List<SseEmitter> userEmitters = emitters.get(userId);
+        if (userEmitters != null) {
+            userEmitters.remove(emitter);
+            log.info("[SSE] 연결 삭제 UserId: {}", userId);
+
+            if (userEmitters.isEmpty()) {
+                emitters.remove(userId);
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/chzz/market/domain/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package org.chzz.market.domain.notification.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,9 +14,9 @@ import org.chzz.market.domain.notification.error.NotificationErrorCode;
 import org.chzz.market.domain.notification.error.NotificationException;
 import org.chzz.market.domain.notification.repository.EmitterRepositoryImpl;
 import org.chzz.market.domain.notification.repository.NotificationRepository;
-import org.chzz.market.domain.token.entity.TokenType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -36,7 +37,7 @@ public class NotificationService {
      * @return SseEmitter 객체
      */
     public SseEmitter subscribe(Long userId) {
-        SseEmitter emitter = new SseEmitter(TokenType.ACCESS.getExpirationTime() * 1000L);
+        SseEmitter emitter = new SseEmitter(25 * 60 * 60 * 1000L); // 25시간으로 설정
         emitterRepository.save(userId, emitter);
         setupEmitterCallbacks(userId, emitter);
         sendInitialConnectionEvent(userId, emitter);
@@ -50,21 +51,26 @@ public class NotificationService {
      * @param userId      사용자 ID
      */
     public void sendRealTimeNotification(Long userId, NotificationSseResponse sseResponse) {
-        Optional<SseEmitter> findEmitter = emitterRepository.findById(userId);
-        findEmitter.ifPresent(emitter -> {
-            try {
-                emitter.send(SseEmitter.event()
-                        .id(userId + "_" + Instant.now().toEpochMilli())
-                        .name("notification")
-                        .data(objectMapper.writeValueAsString(sseResponse)));
-                log.info("SSE 전송: userId: {}, sseResponse: {}", userId, sseResponse);
-            } catch (IOException e) {
-                // 내부에서 추가로 IOException이 발생하므로, 프레임워크의 예외 처리 핸들러에 처리
-                log.info("사용자 ID {}의 끊어진 SSE 연결을 정리합니다.", userId);
-            }
+        Optional<List<SseEmitter>> findEmitter = emitterRepository.findByUserId(userId);
+        findEmitter.ifPresent(emitters -> {
+            emitters.forEach(emitter -> {
+                try {
+                    emitter.send(SseEmitter.event()
+                            .id(userId + "_" + Instant.now().toEpochMilli())
+                            .name("notification")
+                            .data(objectMapper.writeValueAsString(sseResponse)));
+                    log.info("[SSE] 알림 전송 성공 UserId: {} {}", userId, sseResponse);
+                } catch (IOException e) {
+                    // 내부에서 추가로 IOException이 발생하므로, 프레임워크의 예외 처리 핸들러에 처리
+                    log.info("[SSE] 연결 정리 UserId: {}", userId);
+                }
+            });
         });
     }
 
+    /**
+     * 사용자의 알림 조회
+     */
     public Page<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
         return notificationRepository.findByUserId(userId, pageable);
     }
@@ -82,6 +88,23 @@ public class NotificationService {
     }
 
     /**
+     * 모든 emitters에 하트비트 메시지를 주기적으로 전송하여 연결 상태를 확인
+     */
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void sendHeartbeats() {
+        emitterRepository.findAllEmitters().forEach((userId, emitters) -> {
+            emitters.forEach(emitter -> {
+                try {
+                    emitter.send(SseEmitter.event().comment("heartbeat"));
+                } catch (IOException e) {
+                    // 내부에서 추가로 IOException이 발생하므로, 프레임워크의 예외 처리 핸들러에 처리
+                    log.info("[SSE] 연결 정리 UserId: {}", userId);
+                }
+            });
+        });
+    }
+
+    /**
      * SseEmitter의 콜백을 설정합니다.
      *
      * @param userId  사용자 ID
@@ -89,11 +112,11 @@ public class NotificationService {
      */
     private void setupEmitterCallbacks(Long userId, SseEmitter emitter) {
         emitter.onCompletion(() -> {
-            emitterRepository.deleteById(userId);
-            log.info("SSE connection completed for user {}", userId);
+            emitterRepository.deleteEmitter(userId, emitter);
+            log.info("[SSE] 연결 종료 UserId: {}", userId);
         });
         emitter.onTimeout(() -> {
-            log.info("SSE connection timed out for user {}", userId);
+            log.info("[SSE] 시간 초과 UserId: {}", userId);
         });
     }
 
@@ -105,13 +128,13 @@ public class NotificationService {
      */
     private void sendInitialConnectionEvent(Long userId, SseEmitter emitter) {
         try {
-            log.info("User {} subscribed to notifications with initial connection", userId);
+            log.info("[SSE] 연결 성공 UserId: {}", userId);
             emitter.send(SseEmitter.event()
                     .id(userId + "_" + Instant.now().toEpochMilli())
                     .name("init")
                     .data("Connection Established"));
         } catch (Exception e) {
-            log.error("Error sending initial connection event to user {}", userId);
+            log.info("[SSE] 연결 실패 UserId: {}", userId);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-156]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 서버 성능을 위해 기존에 끊긴 SSE 연결 정리를 위해 주기적으로 저장된 SseEmitter에 하트비트 인 빈 주석을 보냈습니다.
- 주기적으로 확인하기 때문에 잦은 재연결 요청을 받지 않기 위해 타임아웃 시간을 길게 잡았습니다.
- 현재 경매시간이 24시간이기 때문에, 경매 시작하자마자 켜뒀다고 가정하에 볼 수 있게 알림이 올 수 있게 하기 위해 25시간으로 설정 해뒀습니다.
- Nginx의 proxy_read_timeout도 서버에서 하트비트를 1분마다 보내기 때문에 1분보다 살짝 긴 1분 30초안에 응답이 없으면 연결을 끊습니다.
- 간단한 스케줄링이기 때문에 기본 스프링 스케줄러 사용하였습니다.(Quartz는 복잡한 스케줄러나 특정시각에 예약스케줄러에 사용)
## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->
![스크린샷 2024-10-19 오전 4 00 48](https://github.com/user-attachments/assets/991ce713-3b40-41d6-be55-959d46b991d5)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 여기에 내용을 입력하세요.


[CHZZ-156]: https://chzz-market.atlassian.net/browse/CHZZ-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ