### PR TITLE
feat: 낙찰 정보 조회 기능 추가

### DIFF
--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -117,6 +117,14 @@ public class AuctionController {
     }
 
     /**
+     * 낙찰 정보 조회
+     */
+    @GetMapping("/{auctionId}/winning-bid")
+    public ResponseEntity<WonAuctionResponse> getWinningBid(@LoginUser Long userId, @PathVariable Long auctionId) {
+        return ResponseEntity.ok(auctionService.getWinningBidByAuctionId(userId, auctionId));
+    }
+
+    /**
      * 사용자가 등록한 모든 경매 목록 조회 현재 사용 X
      */
     @GetMapping("/users")

--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionController.java
@@ -12,6 +12,7 @@ import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.RegisterResponse;
 import org.chzz.market.domain.auction.dto.response.StartAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.auction.service.AuctionRegistrationServiceFactory;
 import org.chzz.market.domain.auction.service.AuctionService;
@@ -120,7 +121,7 @@ public class AuctionController {
      * 낙찰 정보 조회
      */
     @GetMapping("/{auctionId}/winning-bid")
-    public ResponseEntity<WonAuctionResponse> getWinningBid(@LoginUser Long userId, @PathVariable Long auctionId) {
+    public ResponseEntity<WonAuctionDetailsResponse> getWinningBid(@LoginUser Long userId, @PathVariable Long auctionId) {
         return ResponseEntity.ok(auctionService.getWinningBidByAuctionId(userId, auctionId));
     }
 

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/LostAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/LostAuctionResponse.java
@@ -9,8 +9,9 @@ public record LostAuctionResponse (
         String productName,
         String imageUrl,
         Integer minPrice,
+        Long participantCount,
         LocalDateTime endDateTime,
-        Long highestAmount
+        Long bidAmount
 ) {
     @QueryProjection
     public LostAuctionResponse {}

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionDetailsResponse.java
@@ -1,0 +1,13 @@
+package org.chzz.market.domain.auction.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record WonAuctionDetailsResponse(
+        Long auctionId,
+        String productName,
+        String imageUrl,
+        Long winningAmount
+) {
+    @QueryProjection
+    public WonAuctionDetailsResponse {}
+}

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionResponse.java
@@ -9,6 +9,7 @@ public record WonAuctionResponse (
         String productName,
         String imageUrl,
         Integer minPrice,
+        Long participantCount,
         LocalDateTime endDateTime,
         Long winningAmount
 ) {

--- a/src/main/java/org/chzz/market/domain/auction/entity/Auction.java
+++ b/src/main/java/org/chzz/market/domain/auction/entity/Auction.java
@@ -126,6 +126,6 @@ public class Auction extends BaseTimeEntity {
      * 낙찰자인지 확인
      */
     public boolean isWinner(Long userId) {
-        return userId.equals(winnerId);
+        return winnerId != null && winnerId.equals(userId);
     }
 }

--- a/src/main/java/org/chzz/market/domain/auction/entity/Auction.java
+++ b/src/main/java/org/chzz/market/domain/auction/entity/Auction.java
@@ -115,24 +115,17 @@ public class Auction extends BaseTimeEntity {
         }
     }
 
-    /*
+    /**
      * 경매가 진행중인지 확인
      */
     public boolean isProceeding() {
         return status == PROCEEDING && LocalDateTime.now().isBefore(endDateTime);
     }
 
-    /*
-     * 사용자가 낙찰에 성공한 경매인지 확인
+    /**
+     * 낙찰자인지 확인
      */
-    public boolean isSuccessfulBidFor(Long userId) {
-        return status == ENDED && winnerId != null && winnerId.equals(userId);
-    }
-
-    /*
-     * 사용자가 낙찰에 실패한 경매인지 확인
-     */
-    public boolean isFailedBidFor(Long userId) {
-        return status == ENDED && (winnerId == null || !winnerId.equals(userId));
+    public boolean isWinner(Long userId) {
+        return userId.equals(winnerId);
     }
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
@@ -106,11 +106,16 @@ public interface AuctionRepositoryCustom {
     Page<UserAuctionResponse> findProceedingAuctionByUserId(Long userId, Pageable pageable);
 
     /**
-     * 사용자 ID에 해당하는 종료된 경매 목록을 페이징항여 조회합니다.
+     * 사용자 ID에 해당하는 종료된 경매 목록을 페이징하여 조회합니다.
      *
      * @param userId   경매를 조회할 사용자 ID
      * @param pageable 페이징 정보 (페이지 번호, 페이지 크기 등)
      * @return 종료된 경매 목록을 포함한 페이징 결과
      */
     Page<UserEndedAuctionResponse> findEndedAuctionByUserId(Long userId, Pageable pageable);
+
+    /**
+     * 낙찰 정보 조회합니다.
+     */
+    Optional<WonAuctionResponse> findWinningBidById(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustom.java
@@ -8,6 +8,7 @@ import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.product.entity.Product.Category;
 import org.chzz.market.domain.user.dto.response.ParticipationCountsResponse;
@@ -117,5 +118,5 @@ public interface AuctionRepositoryCustom {
     /**
      * 낙찰 정보 조회합니다.
      */
-    Optional<WonAuctionResponse> findWinningBidById(Long auctionId);
+    Optional<WonAuctionDetailsResponse> findWinningBidById(Long auctionId);
 }

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -486,6 +486,25 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Optional<WonAuctionResponse> findWinningBidById(Long auctionId) {
+        return Optional.ofNullable(jpaQueryFactory.select(
+                        new QWonAuctionResponse(
+                                auction.id,
+                                product.name,
+                                image.cdnPath,
+                                product.minPrice,
+                                auction.endDateTime,
+                                bid.amount
+                        ))
+                .from(auction)
+                .join(bid).on(bid.bidder.id.eq(auction.winnerId))
+                .join(auction.product, product)
+                .leftJoin(image).on(image.product.id.eq(product.id)
+                        .and(image.id.eq(getFirstImageId())))
+                .fetchOne());
+    }
+
     /**
      * @param userId 사용자 pk
      * @return 실제 사용자가 참여한 경매(취소된 입찰 제외)

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -498,7 +498,9 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                                 bid.amount
                         ))
                 .from(auction)
-                .join(bid).on(bid.bidder.id.eq(auction.winnerId))
+                .join(bid).on(bid.auction.eq(auction)
+                        .and(auction.id.eq(auctionId))
+                        .and(auction.winnerId.eq(bid.bidder.id)))
                 .join(auction.product, product)
                 .leftJoin(image).on(image.product.id.eq(product.id)
                         .and(image.id.eq(getFirstImageId())))

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -1,7 +1,9 @@
 package org.chzz.market.domain.auction.service;
 
+import static org.chzz.market.common.error.GlobalErrorCode.RESOURCE_NOT_FOUND;
 import static org.chzz.market.domain.auction.error.AuctionErrorCode.AUCTION_ALREADY_REGISTERED;
 import static org.chzz.market.domain.auction.error.AuctionErrorCode.AUCTION_NOT_FOUND;
+import static org.chzz.market.domain.auction.error.AuctionErrorCode.NOT_WINNER;
 import static org.chzz.market.domain.notification.entity.NotificationType.AUCTION_FAILURE;
 import static org.chzz.market.domain.notification.entity.NotificationType.AUCTION_NON_WINNER;
 import static org.chzz.market.domain.notification.entity.NotificationType.AUCTION_START;
@@ -14,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.chzz.market.common.error.GlobalException;
 import org.chzz.market.domain.auction.dto.request.StartAuctionRequest;
 import org.chzz.market.domain.auction.dto.response.AuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.AuctionResponse;
@@ -49,14 +52,6 @@ public class AuctionService {
     private final AuctionRepository auctionRepository;
     private final ProductRepository productRepository;
     private final ApplicationEventPublisher eventPublisher;
-
-    /**
-     * 경매 ID로 경매 정보를 조회
-     */
-    public Auction getAuction(Long auctionId) {
-        return auctionRepository.findById(auctionId)
-                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
-    }
 
     /**
      * 카테고리에 따라 경매 리스트를 조회
@@ -142,6 +137,18 @@ public class AuctionService {
     }
 
     /**
+     * 낙찰 정보 조회
+     */
+    public WonAuctionResponse getWinningBidByAuctionId(Long userId, Long auctionId) {
+        Auction auction = getAuctionById(auctionId);
+        if (!auction.isWinner(userId)) {
+            throw new AuctionException(NOT_WINNER);
+        }
+        return auctionRepository.findWinningBidById(auctionId)
+                .orElseThrow(() -> new GlobalException(RESOURCE_NOT_FOUND));
+    }
+
+    /**
      * 사전 등록 상품 경매 전환 처리
      */
     @Transactional
@@ -181,9 +188,17 @@ public class AuctionService {
     @Transactional
     public void completeAuction(Long auctionId) {
         log.info("경매 종료 작업 시작 auction ID: {}", auctionId);
-        Auction auction = getAuction(auctionId);
+        Auction auction = getAuctionById(auctionId);
         auction.endAuction();
         processAuctionResults(auction);
+    }
+
+    /**
+     * 경매 ID로 경매 정보를 조회
+     */
+    private Auction getAuctionById(Long auctionId) {
+        return auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -142,7 +142,7 @@ public class AuctionService {
      */
     public WonAuctionDetailsResponse getWinningBidByAuctionId(Long userId, Long auctionId) {
         Auction auction = getAuctionById(auctionId);
-        if (!auction.isWinner(userId) || auction.getProduct().isOwner(userId)) {
+        if (!auction.isWinner(userId)) {
             throw new AuctionException(NOT_WINNER);
         }
         return auctionRepository.findWinningBidById(auctionId)

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -24,6 +24,7 @@ import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.StartAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.auction.error.AuctionException;
@@ -139,9 +140,9 @@ public class AuctionService {
     /**
      * 낙찰 정보 조회
      */
-    public WonAuctionResponse getWinningBidByAuctionId(Long userId, Long auctionId) {
+    public WonAuctionDetailsResponse getWinningBidByAuctionId(Long userId, Long auctionId) {
         Auction auction = getAuctionById(auctionId);
-        if (!auction.isWinner(userId)) {
+        if (!auction.isWinner(userId) || auction.getProduct().isOwner(userId)) {
             throw new AuctionException(NOT_WINNER);
         }
         return auctionRepository.findWinningBidById(auctionId)

--- a/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/product/repository/ProductRepositoryCustomImpl.java
@@ -12,9 +12,7 @@ import static org.chzz.market.domain.user.entity.QUser.user;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -27,7 +25,6 @@ import org.chzz.market.common.util.QuerydslOrder;
 import org.chzz.market.common.util.QuerydslOrderProvider;
 import org.chzz.market.domain.image.dto.ImageResponse;
 import org.chzz.market.domain.image.dto.QImageResponse;
-import org.chzz.market.domain.image.entity.QImage;
 import org.chzz.market.domain.product.dto.ProductDetailsResponse;
 import org.chzz.market.domain.product.dto.ProductResponse;
 import org.chzz.market.domain.product.dto.QProductDetailsResponse;
@@ -65,7 +62,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         product.likes.size().longValue(),
                         isProductLikedByUser(userId)
                 ))
-                .leftJoin(image).on(image.product.id.eq(product.id).and(image.id.eq(getFirstImageId())))
+                .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
                 .groupBy(product.id, product.name, image.cdnPath, product.minPrice)
                 .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())
@@ -152,8 +149,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         product.likes.size().longValue(),
                         like.isNotNull()
                 ))
-                .leftJoin(image).on(image.product.id.eq(product.id)
-                        .and(image.id.eq(getFirstImageId())))
+                .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
                 .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -189,8 +185,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                         product.minPrice,
                         product.likes.size().longValue()
                 ))
-                .leftJoin(image).on(image.product.id.eq(product.id)
-                        .and(image.id.eq(getFirstImageId())))
+                .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
                 .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -223,12 +218,13 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
                 .fetch();
     }
 
-    private JPQLQuery<Long> getFirstImageId() {
-        QImage imageSub = new QImage("imageSub");
-        return JPAExpressions.select(imageSub.id)
-                .from(imageSub)
-                .where(imageSub.product.id.eq(product.id)
-                        , imageSub.sequence.eq(Expressions.asNumber(1)));
+    /**
+     * 상품의 대표 이미지를 조회하기 위한 조건을 반환합니다.
+     *
+     * @return 대표 이미지(첫 번째 이미지)의 sequence가 1인 조건식
+     */
+    private BooleanExpression isRepresentativeImage() {
+        return image.sequence.eq(1);
     }
 
     /**

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -21,6 +21,7 @@ import org.chzz.market.domain.auction.dto.response.AuctionResponse;
 import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.bid.entity.Bid.BidStatus;
@@ -128,7 +129,8 @@ class AuctionRepositoryCustomImplTest {
                 .endDateTime(LocalDateTime.now().minusDays(1))
                 .build();
         auctionRepository.saveAll(
-                List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9, auction10));
+                List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9,
+                        auction10));
 
         // auction8에 대한 결제 데이터 추가 (결제 완료된 경매)
         TossPaymentResponse tossPaymentResponse = new TossPaymentResponse();
@@ -706,6 +708,32 @@ class AuctionRepositoryCustomImplTest {
         assertThat(auction9Response.isWon()).isFalse();
         assertThat(auction9Response.isPaid()).isFalse(); // 결제 없음
         assertThat(auction9Response.participantCount()).isEqualTo(0); // 입찰 없음
+    }
+
+    @Test
+    @DisplayName("낙찰정보 조회에 성공한다.")
+    public void findWinningBidById_Success() {
+        //given
+        Long auctionId = auction8.getId();
+
+        //when
+        Optional<WonAuctionResponse> result = auctionRepository.findWinningBidById(auctionId);
+        WonAuctionResponse response = result.get();
+        //then
+        assertThat(response.auctionId()).isEqualTo(auction8.getId());
+        assertThat(response.productName()).isEqualTo(product8.getName());
+        assertThat(response.winningAmount()).isEqualTo(250000L);
+    }
+
+    @Test
+    @DisplayName("낙찰정보가 없는 경매조회시 빈 Optional를 반환한다.")
+    public void findWinningBidById_EmptyOptional_WhenNoWinningBid() {
+        //given
+        Long auctionId = auction9.getId();
+
+        //when
+        Optional<WonAuctionResponse> result = auctionRepository.findWinningBidById(auctionId);
+        assertThat(result).isEmpty();
     }
 
 }

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -21,6 +21,7 @@ import org.chzz.market.domain.auction.dto.response.AuctionResponse;
 import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.UserEndedAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
@@ -468,7 +469,7 @@ class AuctionRepositoryCustomImplTest {
         assertThat(firstLost.productName()).isEqualTo("제품4");
         assertThat(firstLost.imageUrl()).isEqualTo("path/to/image4.jpg");
         assertThat(firstLost.minPrice()).isEqualTo(40000);
-        assertThat(firstLost.highestAmount()).isEqualTo(25000L); // 최고 입찰가 (user4의 입찰)
+        assertThat(firstLost.bidAmount()).isEqualTo(15000L);
 
         // 두 번째 실패한 경매
         LostAuctionResponse secondLost = result.getContent().get(1);
@@ -476,7 +477,7 @@ class AuctionRepositoryCustomImplTest {
         assertThat(secondLost.productName()).isEqualTo("제품8");
         assertThat(secondLost.imageUrl()).isEqualTo("path/to/image5.jpg");
         assertThat(secondLost.minPrice()).isEqualTo(75000);
-        assertThat(secondLost.highestAmount()).isEqualTo(250000L); // 최고 입찰가 (user3의 입찰)
+        assertThat(secondLost.bidAmount()).isEqualTo(150000L);
 
         // 정렬 순서 확인 (종료 시간 기준 내림차순)
         assertThat(result.getContent()).isSortedAccordingTo(
@@ -717,8 +718,8 @@ class AuctionRepositoryCustomImplTest {
         Long auctionId = auction8.getId();
 
         //when
-        Optional<WonAuctionResponse> result = auctionRepository.findWinningBidById(auctionId);
-        WonAuctionResponse response = result.get();
+        Optional<WonAuctionDetailsResponse> result = auctionRepository.findWinningBidById(auctionId);
+        WonAuctionDetailsResponse response = result.get();
         //then
         assertThat(response.auctionId()).isEqualTo(auction8.getId());
         assertThat(response.productName()).isEqualTo(product8.getName());
@@ -732,7 +733,7 @@ class AuctionRepositoryCustomImplTest {
         Long auctionId = auction9.getId();
 
         //when
-        Optional<WonAuctionResponse> result = auctionRepository.findWinningBidById(auctionId);
+        Optional<WonAuctionDetailsResponse> result = auctionRepository.findWinningBidById(auctionId);
         assertThat(result).isEmpty();
     }
 

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -36,6 +36,7 @@ import org.chzz.market.domain.auction.dto.response.LostAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.RegisterResponse;
 import org.chzz.market.domain.auction.dto.response.SimpleAuctionResponse;
 import org.chzz.market.domain.auction.dto.response.StartAuctionResponse;
+import org.chzz.market.domain.auction.dto.response.WonAuctionDetailsResponse;
 import org.chzz.market.domain.auction.dto.response.WonAuctionResponse;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.auction.error.AuctionException;
@@ -449,8 +450,8 @@ class AuctionServiceTest {
             Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<WonAuctionResponse> wonAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, LocalDateTime.now(), 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, LocalDateTime.now(), 25000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
             );
 
             Page<WonAuctionResponse> mockPage = new PageImpl<>(wonAuctions, pageable, wonAuctions.size());
@@ -501,8 +502,8 @@ class AuctionServiceTest {
             Pageable secondPageable = PageRequest.of(1, 1, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<WonAuctionResponse> allAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, LocalDateTime.now(), 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, LocalDateTime.now(), 25000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
             );
 
             Page<WonAuctionResponse> firstPage = new PageImpl<>(allAuctions.subList(0, 1), firstPageable,
@@ -536,9 +537,9 @@ class AuctionServiceTest {
 
             LocalDateTime now = LocalDateTime.now();
             List<WonAuctionResponse> wonAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, now, 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, now.minusHours(1), 25000L),
-                    new WonAuctionResponse(3L, "Product 3", "image3.jpg", 30000, now.minusHours(2), 35000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, now, 15000L),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, now.minusHours(1), 25000L),
+                    new WonAuctionResponse(3L, "Product 3", "image3.jpg", 30000, 3L, now.minusHours(2), 35000L)
             );
 
             Page<WonAuctionResponse> mockPage = new PageImpl<>(wonAuctions, pageable, wonAuctions.size());
@@ -569,8 +570,8 @@ class AuctionServiceTest {
             Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<LostAuctionResponse> LostAuctions = List.of(
-                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, LocalDateTime.now(), 15000L),
-                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, LocalDateTime.now(), 25000L)
+                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
+                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
             );
 
             Page<LostAuctionResponse> mockPage = new PageImpl<>(LostAuctions, pageable, LostAuctions.size());
@@ -621,8 +622,8 @@ class AuctionServiceTest {
             Pageable secondPageable = PageRequest.of(1, 1, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<LostAuctionResponse> allAuctions = List.of(
-                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, LocalDateTime.now(), 15000L),
-                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, LocalDateTime.now(), 25000L)
+                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
+                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
             );
 
             Page<LostAuctionResponse> firstPage = new PageImpl<>(allAuctions.subList(0, 1), firstPageable,
@@ -656,9 +657,9 @@ class AuctionServiceTest {
 
             LocalDateTime now = LocalDateTime.now();
             List<LostAuctionResponse> lostAuctions = List.of(
-                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, now, 15000L),
-                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, now.minusHours(1), 25000L),
-                    new LostAuctionResponse(3L, "Product 3", "image3.jpg", 30000, now.minusHours(2), 35000L)
+                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, now, 15000L),
+                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, now.minusHours(1), 25000L),
+                    new LostAuctionResponse(3L, "Product 3", "image3.jpg", 30000, 3L, now.minusHours(2), 35000L)
             );
 
             Page<LostAuctionResponse> mockPage = new PageImpl<>(lostAuctions, pageable, lostAuctions.size());
@@ -685,8 +686,8 @@ class AuctionServiceTest {
             Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<LostAuctionResponse> lostAuctions = List.of(
-                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, LocalDateTime.now(), 15000L),
-                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, LocalDateTime.now(), 25000L)
+                    new LostAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
+                    new LostAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
             );
 
             Page<LostAuctionResponse> mockPage = new PageImpl<>(lostAuctions, pageable, lostAuctions.size());
@@ -698,8 +699,8 @@ class AuctionServiceTest {
 
             // then
             assertThat(resultPage.getContent()).hasSize(2);
-            assertThat(resultPage.getContent().get(0).highestAmount()).isEqualTo(15000L);
-            assertThat(resultPage.getContent().get(1).highestAmount()).isEqualTo(25000L);
+            assertThat(resultPage.getContent().get(0).bidAmount()).isEqualTo(15000L);
+            assertThat(resultPage.getContent().get(1).bidAmount()).isEqualTo(25000L);
 
             verify(auctionRepository, times(1)).findLostAuctionHistoryByUserId(userId, pageable);
         }
@@ -711,16 +712,21 @@ class AuctionServiceTest {
         @Test
         @DisplayName("정상적으로 낙찰 정보를 조회한다.")
         public void getWinningBidByAuctionId_Success() throws Exception {
+            Product product = Product.builder()
+                    .user(User.builder().id(user.getId() + 1).build())
+                    .build();
+
             //given
             Auction auction = Auction.builder()
                     .id(1L)
+                    .product(product)
                     .winnerId(user.getId())
                     .build();
 
             //when
             when(auctionRepository.findById(auction.getId())).thenReturn(Optional.of(auction));
             when(auctionRepository.findWinningBidById(auction.getId())).thenReturn(
-                    Optional.of(mock(WonAuctionResponse.class)));
+                    Optional.of(mock(WonAuctionDetailsResponse.class)));
 
             //then
             assertDoesNotThrow(() -> auctionService.getWinningBidByAuctionId(user.getId(), auction.getId()));


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-157]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 낙찰자가 낙찰정보를 조회하는 API를 추가하였습니다.
- 성공한 경매목록 조회 API에서 응답하는 DTO를 사용하였습니다.
- 낙찰자가 아닐시 403 에러를 반환합니다.
- 이미 서비스 단에서 낙찰자가 있는 경우에만 쿼리가 실행되도록 처리했지만, fetchOne이 null을 반환하면 NullPointerException이 발생할 위험이 있기에 이를 방지하기 위해 Optional로 처리하여, 값이 없는 경우에는 global exception 404 에러를 던지도록 했습니다.
- 기존에 상품과 이미지를 조인해서 대표이미지 가져오는 부분에서 불필요한 부분을 제거해 최적화하였습니다.

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->
![스크린샷 2024-10-19 오후 7 11 11](https://github.com/user-attachments/assets/a42f88c6-7a9e-40fd-936c-37c9d543d45c)

![스크린샷 2024-10-19 오후 6 52 10](https://github.com/user-attachments/assets/df7adc0a-4cf4-48a7-b160-b6ab62016152)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->


[CHZZ-157]: https://chzz-market.atlassian.net/browse/CHZZ-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ