### PR TITLE
refactor: 주문 도입 이후 나의 성공한 경매 목록 조회 API 수정

### DIFF
--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -26,8 +26,6 @@ public class AuctionDetailsResponse {
     private final Long bidAmount;
     private final int remainingBidCount;
     private final Boolean isCancelled;
-    private final Boolean isOrdered;
-    private final Long orderId;
     private List<ImageResponse> images = new ArrayList<>();
 
     @QueryProjection
@@ -36,7 +34,7 @@ public class AuctionDetailsResponse {
                                   Integer minPrice, Category category, Long timeRemaining, AuctionStatus status,
                                   Boolean isSeller,
                                   Long participantCount, Boolean isParticipated, Long bidId, Long bidAmount,
-                                  int remainingBidCount, Boolean isCancelled, Boolean isOrdered, Long orderId) {
+                                  int remainingBidCount, Boolean isCancelled) {
         this.productId = productId;
         this.sellerNickname = sellerNickname;
         this.sellerProfileImageUrl = sellerProfileImageUrl;
@@ -53,8 +51,6 @@ public class AuctionDetailsResponse {
         this.bidAmount = bidAmount;
         this.remainingBidCount = remainingBidCount;
         this.isCancelled = isCancelled;
-        this.isOrdered = isOrdered;
-        this.orderId = orderId;
     }
 
     public void addImageList(List<ImageResponse> images) {

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -26,6 +26,8 @@ public class AuctionDetailsResponse {
     private final Long bidAmount;
     private final int remainingBidCount;
     private final Boolean isCancelled;
+    private final Boolean isOrdered;
+    private final Long orderId;
     private List<ImageResponse> images = new ArrayList<>();
 
     @QueryProjection
@@ -34,7 +36,7 @@ public class AuctionDetailsResponse {
                                   Integer minPrice, Category category, Long timeRemaining, AuctionStatus status,
                                   Boolean isSeller,
                                   Long participantCount, Boolean isParticipated, Long bidId, Long bidAmount,
-                                  int remainingBidCount, Boolean isCancelled) {
+                                  int remainingBidCount, Boolean isCancelled, Boolean isOrdered, Long orderId) {
         this.productId = productId;
         this.sellerNickname = sellerNickname;
         this.sellerProfileImageUrl = sellerProfileImageUrl;
@@ -51,6 +53,8 @@ public class AuctionDetailsResponse {
         this.bidAmount = bidAmount;
         this.remainingBidCount = remainingBidCount;
         this.isCancelled = isCancelled;
+        this.isOrdered = isOrdered;
+        this.orderId = orderId;
     }
 
     public void addImageList(List<ImageResponse> images) {

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/UserEndedAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/UserEndedAuctionResponse.java
@@ -14,7 +14,7 @@ public record UserEndedAuctionResponse(
         Long participantCount,
         Long winningBidAmount,
         Boolean isWon, // 낙찰 유무
-        Boolean isPaid, // 결제 유무
+        Boolean isOrdered, // 주문 유무
         LocalDateTime createAt
 ) {
 

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/WonAuctionResponse.java
@@ -11,7 +11,9 @@ public record WonAuctionResponse (
         Integer minPrice,
         Long participantCount,
         LocalDateTime endDateTime,
-        Long winningAmount
+        Long winningAmount,
+        Boolean isOrdered,
+        Long orderId
 ) {
     @QueryProjection
     public WonAuctionResponse {}

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -306,7 +306,6 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                 .join(auction.product, product)
                 .where(auction.winnerId.eq(userId).and(auction.status.eq(ENDED)));
 
-        // TODO: leftJoin(Order) 추가 및 필드(주문여부, 주문ID)추가
         List<WonAuctionResponse> content = baseQuery
                 .select(new QWonAuctionResponse(
                         auction.id,
@@ -315,9 +314,12 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                         product.minPrice,
                         getBidCount(),
                         auction.endDateTime,
-                        bid.amount
+                        bid.amount,
+                        order.isNotNull(),
+                        order.id
                 ))
                 .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
+                .leftJoin(order).on(order.auction.id.eq(auction.id))
                 .groupBy(auction.id, product.name, image.cdnPath, product.minPrice, bid.amount)
                 .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -17,7 +17,6 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Ops.DateTimeOps;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.DateTimeOperation;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -130,11 +129,7 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                         activeBid.id,
                         activeBid.amount.coalesce(0L),
                         activeBid.count.coalesce(3),
-                        canceledBid.id.isNotNull(),
-                        order.isNotNull(),// 주문 여부 확인
-                        new CaseBuilder().when(order.id.isNotNull())
-                                .then(order.id)// 주문한 경우 ID를 반환(추후 조회 가능하도록)
-                                .otherwise(Expressions.nullExpression()).as("orderId")// 주문여부가 없는경우 null 반환
+                        canceledBid.id.isNotNull()
                 ))
                 .from(auction)
                 .join(auction.product, product)
@@ -147,7 +142,6 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                 .leftJoin(canceledBid).on(canceledBid.auction.id.eq(auctionId)
                         .and(canceledBid.status.eq(CANCELLED)) // CANCELED 상태인 입찰 조인
                         .and(bidderIdEqSub(canceledBid, userId)))
-                .leftJoin(order).on(order.auction.eq(auction))
                 .where(auction.id.eq(auctionId))
                 .fetchOne());
 

--- a/src/main/java/org/chzz/market/domain/order/service/OrderService.java
+++ b/src/main/java/org/chzz/market/domain/order/service/OrderService.java
@@ -7,7 +7,7 @@ import org.chzz.market.domain.address.exception.AddressException;
 import org.chzz.market.domain.address.repository.AddressRepository;
 import org.chzz.market.domain.order.entity.Order;
 import org.chzz.market.domain.order.repository.OrderRepository;
-import org.chzz.market.domain.payment.dto.DeliveryRequest;
+import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
 import org.chzz.market.domain.payment.dto.SuccessfulPaymentEvent;
 import org.chzz.market.domain.payment.entity.Payment;
 import org.springframework.scheduling.annotation.Async;
@@ -25,10 +25,10 @@ public class OrderService {
     public void completedTransactionProcess(SuccessfulPaymentEvent event) {
         Long userId = event.userId();
         Payment payment = event.payment();
-        DeliveryRequest deliveryRequest = event.deliveryRequest();
-        Address address = addressRepository.findById(deliveryRequest.addressId())
+        ShippingAddressRequest shippingAddressRequest = event.shippingAddressRequest();
+        Address address = addressRepository.findById(shippingAddressRequest.addressId())
                 .orElseThrow(() -> new AddressException(AddressErrorCode.NOT_FOUND));
-        Order order = Order.of(userId, payment, address, deliveryRequest.memo());
+        Order order = Order.of(userId, payment, address, shippingAddressRequest.memo());
         orderRepository.save(order);
     }
 }

--- a/src/main/java/org/chzz/market/domain/payment/dto/DeliveryRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/DeliveryRequest.java
@@ -1,8 +1,0 @@
-package org.chzz.market.domain.payment.dto;
-
-import jakarta.annotation.Nullable;
-
-public record DeliveryRequest(Long addressId,
-                              @Nullable
-                              String memo) {
-}

--- a/src/main/java/org/chzz/market/domain/payment/dto/ShippingAddressRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/ShippingAddressRequest.java
@@ -1,0 +1,8 @@
+package org.chzz.market.domain.payment.dto;
+
+import jakarta.annotation.Nullable;
+
+public record ShippingAddressRequest(Long addressId,
+                                     @Nullable
+                                     String memo) {
+}

--- a/src/main/java/org/chzz/market/domain/payment/dto/SuccessfulPaymentEvent.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/SuccessfulPaymentEvent.java
@@ -2,5 +2,5 @@ package org.chzz.market.domain.payment.dto;
 
 import org.chzz.market.domain.payment.entity.Payment;
 
-public record SuccessfulPaymentEvent(Long userId, Payment payment, DeliveryRequest deliveryRequest) {
+public record SuccessfulPaymentEvent(Long userId, Payment payment, ShippingAddressRequest shippingAddressRequest) {
 }

--- a/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
@@ -1,10 +1,10 @@
 package org.chzz.market.domain.payment.dto.request;
 
-import org.chzz.market.domain.payment.dto.DeliveryRequest;
+import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
 
 public record ApprovalRequest(String orderId,
                               String paymentKey,
                               Long amount,
                               Long auctionId,
-                              DeliveryRequest deliveryRequest) {
+                              ShippingAddressRequest shippingAddressRequest) {
 }

--- a/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
@@ -7,7 +7,7 @@ import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.auction.error.AuctionErrorCode;
 import org.chzz.market.domain.auction.error.AuctionException;
 import org.chzz.market.domain.auction.repository.AuctionRepository;
-import org.chzz.market.domain.payment.dto.DeliveryRequest;
+import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
 import org.chzz.market.domain.payment.dto.SuccessfulPaymentEvent;
 import org.chzz.market.domain.payment.dto.request.ApprovalRequest;
 import org.chzz.market.domain.payment.dto.response.ApprovalResponse;
@@ -41,7 +41,7 @@ public class PaymentService {
     private final ApplicationEventPublisher eventPublisher;
 
     public ApprovalResponse approval(Long userId, ApprovalRequest request) {
-        DeliveryRequest deliveryRequest = request.deliveryRequest();
+        ShippingAddressRequest shippingAddressRequest = request.shippingAddressRequest();
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         // DONE 상태의 결제 내역이 있는경우 예외처리
         validateDuplicatePayment(userId, request.auctionId());
@@ -54,7 +54,7 @@ public class PaymentService {
             throw new AuctionException(AuctionErrorCode.NOT_WINNER);
         }
         Payment payment = savePayment(user, tossPaymentResponse, auction);
-        eventPublisher.publishEvent(new SuccessfulPaymentEvent(userId,payment,deliveryRequest));
+        eventPublisher.publishEvent(new SuccessfulPaymentEvent(userId,payment, shippingAddressRequest));
         return ApprovalResponse.of(tossPaymentResponse);
     }
 

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -450,8 +450,8 @@ class AuctionServiceTest {
             Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<WonAuctionResponse> wonAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L,false,null),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L,false,null)
             );
 
             Page<WonAuctionResponse> mockPage = new PageImpl<>(wonAuctions, pageable, wonAuctions.size());
@@ -502,8 +502,8 @@ class AuctionServiceTest {
             Pageable secondPageable = PageRequest.of(1, 1, Sort.by(Sort.Direction.DESC, "endDateTime"));
 
             List<WonAuctionResponse> allAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, LocalDateTime.now(), 15000L,false,null),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, LocalDateTime.now(), 25000L,false,null)
             );
 
             Page<WonAuctionResponse> firstPage = new PageImpl<>(allAuctions.subList(0, 1), firstPageable,
@@ -537,9 +537,9 @@ class AuctionServiceTest {
 
             LocalDateTime now = LocalDateTime.now();
             List<WonAuctionResponse> wonAuctions = List.of(
-                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, now, 15000L),
-                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, now.minusHours(1), 25000L),
-                    new WonAuctionResponse(3L, "Product 3", "image3.jpg", 30000, 3L, now.minusHours(2), 35000L)
+                    new WonAuctionResponse(1L, "Product 1", "image1.jpg", 10000, 3L, now, 15000L,false,null),
+                    new WonAuctionResponse(2L, "Product 2", "image2.jpg", 20000, 3L, now.minusHours(1), 25000L,false,null),
+                    new WonAuctionResponse(3L, "Product 3", "image3.jpg", 30000, 3L, now.minusHours(2), 35000L,false,null)
             );
 
             Page<WonAuctionResponse> mockPage = new PageImpl<>(wonAuctions, pageable, wonAuctions.size());

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -357,7 +357,7 @@ class AuctionServiceTest {
             Long existingAuctionId = 1L;
             Long userId = 1L;
             AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(1L, "닉네임2", "null", "제품1", null, 1000,
-                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false);
+                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false, false, null);
 
             // when
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -357,7 +357,7 @@ class AuctionServiceTest {
             Long existingAuctionId = 1L;
             Long userId = 1L;
             AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(1L, "닉네임2", "null", "제품1", null, 1000,
-                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false, false, null);
+                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false);
 
             // when
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-163]

## 📝작업 내용


- 주문 여부 추가
- 주문을 했다면 주문Id 추가 (추후 주문 내역 조회에 사용)
- 결제여부 ⇒ 주문여부 변경

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- ![image](https://github.com/user-attachments/assets/402bb2f5-19d7-4000-b2e3-17df7792291c)



[CHZZ-163]: https://chzz-market.atlassian.net/browse/CHZZ-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ