### PR TITLE
refactor: 상세정보 조회 API에 주문 및 낙찰 여부 추가

### DIFF
--- a/src/main/java/org/chzz/market/domain/auction/controller/AuctionApi.java
+++ b/src/main/java/org/chzz/market/domain/auction/controller/AuctionApi.java
@@ -48,7 +48,9 @@ public interface AuctionApi {
     @Operation(summary = "내가 실패한 경매 조회")
     ResponseEntity<Page<LostAuctionResponse>> getLostAuctionHistory(Long userId, @ParameterObject Pageable pageable);
 
-    @Operation(summary = "경매 상세 조회")
+    @Operation(summary = "경매 상세 조회",
+            description = "주문 여부는 민감한 정보이므로 낙찰자와 판매자인 경우에만 해당 정보를 확인할 수 있습니다. " +
+                    "그 외의 사용자에게는 주문 여부 필드는 응답에 포함되지 않습니다.")
     ResponseEntity<AuctionDetailsResponse> getAuctionDetails(Long auctionId, Long userId);
 
     @Operation(summary = "경매 입찰 목록 조회")

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -26,6 +26,10 @@ public class AuctionDetailsResponse {
     private final Long bidAmount;
     private final int remainingBidCount;
     private final Boolean isCancelled;
+    private final Boolean isWinner;
+    private final Boolean isWon;
+    private final Boolean isOrdered;
+
     private List<ImageResponse> images = new ArrayList<>();
 
     @QueryProjection
@@ -34,7 +38,8 @@ public class AuctionDetailsResponse {
                                   Integer minPrice, Category category, Long timeRemaining, AuctionStatus status,
                                   Boolean isSeller,
                                   Long participantCount, Boolean isParticipated, Long bidId, Long bidAmount,
-                                  int remainingBidCount, Boolean isCancelled) {
+                                  int remainingBidCount, Boolean isCancelled, Boolean isWinner, Boolean isWon,
+                                  Boolean isOrdered) {
         this.productId = productId;
         this.sellerNickname = sellerNickname;
         this.sellerProfileImageUrl = sellerProfileImageUrl;
@@ -51,6 +56,9 @@ public class AuctionDetailsResponse {
         this.bidAmount = bidAmount;
         this.remainingBidCount = remainingBidCount;
         this.isCancelled = isCancelled;
+        this.isWinner = isWinner;
+        this.isWon = isWon;
+        this.isOrdered = isOrdered;
     }
 
     public void addImageList(List<ImageResponse> images) {

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -1,6 +1,8 @@
 package org.chzz.market.domain.auction.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -26,9 +28,16 @@ public class AuctionDetailsResponse {
     private final Long bidAmount;
     private final int remainingBidCount;
     private final Boolean isCancelled;
+
+    @Schema(description = "낙찰자인지 여부")
     private final Boolean isWinner;
+
+    @Schema(description = "낙찰되었는지 여부")
     private final Boolean isWon;
-    private final Boolean isOrdered;
+
+    @Schema(description = "주문 여부 - 판매자와 낙찰자에게만 제공")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Boolean isOrdered;
 
     private List<ImageResponse> images = new ArrayList<>();
 
@@ -59,6 +68,12 @@ public class AuctionDetailsResponse {
         this.isWinner = isWinner;
         this.isWon = isWon;
         this.isOrdered = isOrdered;
+    }
+
+    public void clearOrderIfNotEligible() {
+        if (!isSeller && !isWinner) {
+            this.isOrdered = null;
+        }
     }
 
     public void addImageList(List<ImageResponse> images) {

--- a/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/response/AuctionDetailsResponse.java
@@ -70,10 +70,11 @@ public class AuctionDetailsResponse {
         this.isOrdered = isOrdered;
     }
 
-    public void clearOrderIfNotEligible() {
+    public AuctionDetailsResponse clearOrderIfNotEligible() {
         if (!isSeller && !isWinner) {
             this.isOrdered = null;
         }
+        return this;
     }
 
     public void addImageList(List<ImageResponse> images) {

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -149,7 +149,6 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                         .and(canceledBid.status.eq(CANCELLED)) // CANCELED 상태인 입찰 조인
                         .and(bidderIdEqSub(canceledBid, userId)))
                 .leftJoin(order).on(order.auction.eq(auction))
-                .on(auction.winnerId.isNotNull().and(winnerIdEq(userId).or(userIdEq(userId)))) // 낙찰자와 판매자로 제한
                 .where(auction.id.eq(auctionId))
                 .fetchOne());
 
@@ -590,7 +589,11 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
     }
 
     private BooleanBuilder winnerIdEq(Long userId) {
-        return nullSafeBuilder(() -> auction.winnerId.eq(userId));
+        return nullSafeBuilder(() -> auction.winnerId.isNotNull().and(auction.winnerId.eq(userId)));
+    }
+
+    private BooleanBuilder buyerIdEq(Long userId) {
+        return nullSafeBuilder(() -> order.buyerId.eq(userId));
     }
 
     @Getter

--- a/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
+++ b/src/main/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImpl.java
@@ -324,7 +324,7 @@ public class AuctionRepositoryCustomImpl implements AuctionRepositoryCustom {
                 ))
                 .leftJoin(image).on(image.product.eq(product).and(isRepresentativeImage()))
                 .leftJoin(order).on(order.auction.id.eq(auction.id))
-                .groupBy(auction.id, product.name, image.cdnPath, product.minPrice, bid.amount)
+                .groupBy(auction.id, product.name, image.cdnPath, product.minPrice, bid.amount, order.id)
                 .orderBy(querydslOrderProvider.getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -71,6 +71,10 @@ public class AuctionService {
      */
     public AuctionDetailsResponse getFullAuctionDetails(Long auctionId, Long userId) {
         return auctionRepository.findAuctionDetailsById(auctionId, userId)
+                .map(response -> {
+                    response.clearOrderIfNotEligible();
+                    return response;
+                })
                 .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
     }
 

--- a/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
+++ b/src/main/java/org/chzz/market/domain/auction/service/AuctionService.java
@@ -71,10 +71,7 @@ public class AuctionService {
      */
     public AuctionDetailsResponse getFullAuctionDetails(Long auctionId, Long userId) {
         return auctionRepository.findAuctionDetailsById(auctionId, userId)
-                .map(response -> {
-                    response.clearOrderIfNotEligible();
-                    return response;
-                })
+                .map(AuctionDetailsResponse::clearOrderIfNotEligible)
                 .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
     }
 

--- a/src/main/java/org/chzz/market/domain/order/entity/Order.java
+++ b/src/main/java/org/chzz/market/domain/order/entity/Order.java
@@ -74,7 +74,7 @@ public class Order {
     @JoinColumn(name = "auction_id")
     private Auction auction;
 
-    public static Order of(Long userId, Payment payment, Address address,String deliveryMemo) {
+    public static Order of(Long userId, Payment payment, Address address, String deliveryMemo) {
         return Order.builder()
                 .buyerId(userId)
                 .paymentId(payment.getId())

--- a/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
@@ -17,7 +17,7 @@ import org.chzz.market.common.validation.annotation.ThousandMultiple;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateProductRequest {
-    @Size(min = 2, message = "제목은 최소 2글자 이상이어야 합니다")
+    @Size(min = 2, max = 30, message = "제목은 최소 2글자 이상 30자 이하여야 합니다")
     private String productName;
 
     @Size(max = 1000, message = "상품 설명은 최대 1000자까지 가능합니다")

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -61,9 +61,6 @@ class AuctionRepositoryCustomImplTest {
     @Autowired
     AuctionRepository auctionRepository;
 
-    @Autowired
-    OrderRepository orderRepository;
-
     private static User user1, user2, user3, user4, user5;
     private static Product product1, product2, product3, product4, product5, product6, product7, product8, product9, product10;
     private static Auction auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9, auction10;

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -105,7 +105,7 @@ class AuctionRepositoryCustomImplTest {
                 .build();
         product9 = Product.builder().user(user3).name("제품9").category(Category.OTHER).minPrice(75000)
                 .build();
-        product10 = Product.builder().user(user2).name("제품9").category(Category.OTHER).minPrice(80000)
+        product10 = Product.builder().user(user2).name("제품10").category(Category.OTHER).minPrice(80000)
                 .build();
 
         productRepository.saveAll(
@@ -130,12 +130,9 @@ class AuctionRepositoryCustomImplTest {
                 .endDateTime(LocalDateTime.now().minusDays(1)).build();
         auction9 = Auction.builder().product(product9).status(PROCEEDING).winnerId(null)
                 .endDateTime(LocalDateTime.now().plusDays(1)).build();
-        // auction9 생성 (종료되었지만 낙찰자가 없는 경매)
-        auction10 = Auction.builder()
-                .product(product10)
-                .status(ENDED)
-                .endDateTime(LocalDateTime.now().minusDays(1))
-                .build();
+        // auction10 생성 (종료되었지만 낙찰자가 없는 경매)
+        auction10 = Auction.builder().product(product10).status(ENDED)
+                .endDateTime(LocalDateTime.now().minusDays(1)).build();
         auctionRepository.saveAll(
                 List.of(auction1, auction2, auction3, auction4, auction5, auction6, auction7, auction8, auction9,
                         auction10));
@@ -744,23 +741,6 @@ class AuctionRepositoryCustomImplTest {
         Long userId = user2.getId(); // user2의 종료된 경매 조회
         Pageable pageable = PageRequest.of(0, 10);
 
-        Order order1= Order.builder()
-                .amount(10000L)
-                .auction(auction8)
-                .buyerId(userId)
-                .paymentId(1L)
-                .orderNo("orderNo")
-                .detailAddress("detailAddress")
-                .deliveryMemo("deliveryMemo")
-                .jibun("jibun")
-                .roadAddress("roadAddress")
-                .phoneNumber("phoneNumber")
-                .recipientName("recipientName")
-                .zipcode("zipcode")
-                .method(PaymentMethod.ACCOUNT_TRANSFER)
-                .build();
-        orderRepository.save(order1);
-
         // when
         Page<UserEndedAuctionResponse> result = auctionRepository.findEndedAuctionByUserId(userId, pageable);
 
@@ -793,10 +773,10 @@ class AuctionRepositoryCustomImplTest {
         assertThat(auction8Response.isOrdered()).isTrue(); // 결제 완료
         assertThat(auction8Response.participantCount()).isEqualTo(2); // bid13, bid14
 
-        // auction9 검증 (낙찰자 없음)
+        // auction10 검증 (낙찰자 없음)
         UserEndedAuctionResponse auction9Response = auctionResponseMap.get(auction10.getId());
         assertNotNull(auction9Response);
-        assertThat(auction9Response.productName()).isEqualTo("제품9");
+        assertThat(auction9Response.productName()).isEqualTo("제품10");
         assertThat(auction9Response.winningBidAmount()).isEqualTo(0L); // 입찰 없음
         assertThat(auction9Response.isWon()).isFalse();
         assertThat(auction9Response.isOrdered()).isFalse(); // 결제 없음

--- a/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/repository/AuctionRepositoryCustomImplTest.java
@@ -414,7 +414,7 @@ class AuctionRepositoryCustomImplTest {
 
     @Test
     @DisplayName("주문이 있을 시 상세정보 조회를 한다")
-    public void asd() throws Exception {
+    public void shouldReturnAuctionDetailsWhenOrderExists() throws Exception {
         //given
         Long auctionId = auction8.getId();
         Long userId = user4.getId();
@@ -433,7 +433,7 @@ class AuctionRepositoryCustomImplTest {
 
     @Test
     @DisplayName("주문이 없을시 상세정보 조회를 한다")
-    public void asd1() throws Exception {
+    public void shouldReturnAuctionDetailsWhenNoOrderExists() throws Exception {
         //given
         Long auctionId = auction9.getId();
         Long userId = null;

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -385,6 +385,48 @@ class AuctionServiceTest {
             });
             assertThat(auctionException.getErrorCode()).isEqualTo(AUCTION_NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("3. 판매자이거나 낙찰자인 경우 isOrdered 값이 유지됨")
+        void testAuctionDetails_WithOrder() {
+            // given
+            Long auctionId = 1L;
+            Long userId = 1L;
+            AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(
+                    1L, "닉네임1", "profile.jpg", "제품1", "설명", 1000,
+                    ELECTRONICS, 100L, PROCEEDING, true, 5L, true, 10L, 1000L, 3, false, true, true, true);
+
+            // 판매자이거나 낙찰자인 경우
+            when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(Optional.of(auctionDetails));
+
+            // when
+            AuctionDetailsResponse result = auctionService.getFullAuctionDetails(auctionId, userId);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getIsOrdered()).isTrue(); // isOrdered 값이 null로 초기화되지 않음
+        }
+
+        @Test
+        @DisplayName("4. 판매자도 낙찰자도 아닌 경우 isOrdered 값이 null로 초기화됨")
+        void testAuctionDetails_NotSellerOrWinner() {
+            // given
+            Long auctionId = 1L;
+            Long userId = 2L; // 판매자나 낙찰자가 아닌 사용자
+            AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(
+                    1L, "닉네임1", "profile.jpg", "제품1", "설명", 1000,
+                    ELECTRONICS, 100L, PROCEEDING, false, 5L, false, null, 0L, 3, false, false, false, true);
+
+            // 판매자나 낙찰자가 아닌 경우
+            when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(Optional.of(auctionDetails));
+
+            // when
+            AuctionDetailsResponse result = auctionService.getFullAuctionDetails(auctionId, userId);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getIsOrdered()).isNull(); // isOrdered 값이 null로 초기화됨
+        }
     }
 
     @Nested

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -387,14 +387,14 @@ class AuctionServiceTest {
         }
 
         @Test
-        @DisplayName("3. 판매자이거나 낙찰자인 경우 isOrdered 값이 유지됨")
-        void testAuctionDetails_WithOrder() {
+        @DisplayName("3. 낙찰자인 경우 isOrdered 값이 유지됨")
+        void shouldMaintainIsOrderedWhenUserIsWinner() {
             // given
             Long auctionId = 1L;
             Long userId = 1L;
             AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(
                     1L, "닉네임1", "profile.jpg", "제품1", "설명", 1000,
-                    ELECTRONICS, 100L, PROCEEDING, true, 5L, true, 10L, 1000L, 3, false, true, true, true);
+                    ELECTRONICS, 100L, PROCEEDING, false, 5L, true, 10L, 1000L, 3, false, true, true, true);
 
             // 판매자이거나 낙찰자인 경우
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(Optional.of(auctionDetails));
@@ -408,8 +408,29 @@ class AuctionServiceTest {
         }
 
         @Test
-        @DisplayName("4. 판매자도 낙찰자도 아닌 경우 isOrdered 값이 null로 초기화됨")
-        void testAuctionDetails_NotSellerOrWinner() {
+        @DisplayName("4. 판매자인 경우 isOrdered 값이 유지됨")
+        void shouldMaintainIsOrderedWhenUserIsSeller() {
+            // given
+            Long auctionId = 1L;
+            Long userId = 1L;
+            AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(
+                    1L, "닉네임1", "profile.jpg", "제품1", "설명", 1000,
+                    ELECTRONICS, 100L, PROCEEDING, true, 5L, false, null, 0L, 3, false, false, true, false);
+
+            // 판매자이거나 낙찰자인 경우
+            when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(Optional.of(auctionDetails));
+
+            // when
+            AuctionDetailsResponse result = auctionService.getFullAuctionDetails(auctionId, userId);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getIsOrdered()).isFalse(); // isOrdered 값이 null로 초기화되지 않음
+        }
+
+        @Test
+        @DisplayName("5. 판매자도 낙찰자도 아닌 경우 isOrdered 값이 null로 초기화됨")
+        void shouldSetIsOrderedToNullWhenNotSellerOrWinner() {
             // given
             Long auctionId = 1L;
             Long userId = 2L; // 판매자나 낙찰자가 아닌 사용자
@@ -419,6 +440,27 @@ class AuctionServiceTest {
 
             // 판매자나 낙찰자가 아닌 경우
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(Optional.of(auctionDetails));
+
+            // when
+            AuctionDetailsResponse result = auctionService.getFullAuctionDetails(auctionId, userId);
+
+            // then
+            assertNotNull(result);
+            assertThat(result.getIsOrdered()).isNull(); // isOrdered 값이 null로 초기화됨
+        }
+
+        @Test
+        @DisplayName("6. 비회원일 경우 isOrdered 값이 null로 초기화됨")
+        void shouldSetIsOrderedToNullForNonMember() {
+            // given
+            Long auctionId = 1L;
+            Long userId = null; // 비회원
+            AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(
+                    1L, "닉네임1", "profile.jpg", "제품1", "설명", 1000,
+                    ELECTRONICS, 100L, PROCEEDING, false, 5L, false, null, 0L, 3, false, false, false, true);
+
+            // 판매자나 낙찰자가 아닌 경우
+            when(auctionRepository.findAuctionDetailsById(auctionId, userId)).thenReturn(Optional.of(auctionDetails));
 
             // when
             AuctionDetailsResponse result = auctionService.getFullAuctionDetails(auctionId, userId);

--- a/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/auction/service/AuctionServiceTest.java
@@ -357,7 +357,7 @@ class AuctionServiceTest {
             Long existingAuctionId = 1L;
             Long userId = 1L;
             AuctionDetailsResponse auctionDetails = new AuctionDetailsResponse(1L, "닉네임2", "null", "제품1", null, 1000,
-                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false);
+                    ELECTRONICS, 123L, PROCEEDING, false, 0L, false, null, 0L, 0, false, false, false, null);
 
             // when
             when(auctionRepository.findAuctionDetailsById(anyLong(), anyLong())).thenReturn(


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-164]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 상세정보에서 주문 여부, 낙찰자 여부, 낙찰여부 필드 세개를 추가하였습니다.
- 주문 여부는 민감한 정보로 판단하여, 판매자와 낙찰자만 확인할 수 있도록 처리하였습니다.
- 판매자나 낙찰자가 아닐 경우, 주문 여부 필드를 `null`로 처리하였고, `@JsonInclude` 어노테이션을 통해 해당 필드는 응답에서 제외되었습니다.
- 쿼리에서 `Case When`을 사용해 처리할 수 있었으나, 해당 부분은 비즈니스 로직이므로 서비스 레이어에서 처리하는 것이 적절하다고 판단하였습니다. 

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

![스크린샷 2024-10-22 오전 2 22 42](https://github.com/user-attachments/assets/ded6fb2a-44ec-4930-8b65-78f2ae6ed59e)

![스크린샷 2024-10-22 오전 2 21 44](https://github.com/user-attachments/assets/bdf103e5-cc29-46ed-8c39-7a1fde8ea6a6)

## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->
- 꼼꼼하게 리뷰 부탁드립니다!

[CHZZ-164]: https://chzz-market.atlassian.net/browse/CHZZ-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ