### PR TITLE
fix: 결제 승인 점검 로직 수정

### DIFF
--- a/src/main/java/org/chzz/market/domain/payment/entity/Payment.java
+++ b/src/main/java/org/chzz/market/domain/payment/entity/Payment.java
@@ -89,6 +89,10 @@ public class Payment extends BaseTimeEntity {
                 tossPaymentResponse.getPaymentKey());
     }
 
+    public boolean isPaymentDone() {
+        return this.status == Status.DONE;
+    }
+
     @AllArgsConstructor
     public enum PaymentMethod {
         CARD("카드"),

--- a/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
@@ -13,7 +13,6 @@ import org.chzz.market.domain.payment.dto.request.ApprovalRequest;
 import org.chzz.market.domain.payment.dto.response.ApprovalResponse;
 import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
 import org.chzz.market.domain.payment.entity.Payment;
-import org.chzz.market.domain.payment.entity.Status;
 import org.chzz.market.domain.payment.error.PaymentErrorCode;
 import org.chzz.market.domain.payment.error.PaymentException;
 import org.chzz.market.domain.payment.repository.PaymentRepository;
@@ -98,16 +97,12 @@ public class PaymentService {
         throw new PaymentException(PaymentErrorCode.CREATION_FAILURE);
     }
 
-    void validateDuplicatePayment(Long userId, Long auctionId) {
+    private void validateDuplicatePayment(Long userId, Long auctionId) {
         paymentRepository.findByPayerIdAndAuctionId(userId, auctionId).stream()
-                .filter(this::isPaymentDone)
+                .filter(Payment::isPaymentDone)
                 .findFirst()
                 .ifPresent(payment -> {
                     throw new PaymentException(PaymentErrorCode.DUPLICATED_REQUEST);
                 });
-    }
-
-    private boolean isPaymentDone(Payment payment) {
-        return Status.DONE.equals(payment.getStatus());
     }
 }

--- a/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
@@ -98,7 +98,7 @@ public class PaymentService {
         throw new PaymentException(PaymentErrorCode.CREATION_FAILURE);
     }
 
-    private void validateDuplicatePayment(Long userId, Long auctionId) {
+    void validateDuplicatePayment(Long userId, Long auctionId) {
         paymentRepository.findByPayerIdAndAuctionId(userId, auctionId).stream()
                 .filter(this::isPaymentDone)
                 .findFirst()

--- a/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
@@ -5,11 +5,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
+import org.chzz.market.domain.auction.entity.Auction;
+import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
+import org.chzz.market.domain.payment.dto.request.ApprovalRequest;
 import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
 import org.chzz.market.domain.payment.entity.Payment;
 import org.chzz.market.domain.payment.entity.Status;
 import org.chzz.market.domain.payment.error.PaymentException;
 import org.chzz.market.domain.payment.repository.PaymentRepository;
+import org.chzz.market.domain.user.entity.User;
+import org.chzz.market.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,14 +31,28 @@ class PaymentServiceTest {
     @Mock
     private PaymentRepository paymentRepository;
 
+    @Mock
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("완료된 결제의 경우 예외를 발생시킨다")
     void assertThatValidateOrderIdWillFilterDone() {
         TossPaymentResponse tossPaymentResponse = new TossPaymentResponse();
         tossPaymentResponse.setStatus(Status.DONE);
-        when(paymentRepository.findByPayerIdAndAuctionId(any(),any()))
-                .thenReturn(List.of(Payment.of(any(), tossPaymentResponse,any())));
-        assertThrows(PaymentException.class, () -> paymentService.validateDuplicatePayment(0L, 0L));
+
+        ShippingAddressRequest shippingAddressRequest = new ShippingAddressRequest(1L, "memo");
+        ApprovalRequest approvalRequest = new ApprovalRequest("orderid", "payment", 1000L, 1L, shippingAddressRequest);
+
+        User user = User.builder()
+                .id(1L)
+                .nickname("닉네임")
+                .bio("자기소개")
+                .build();
+        when(userRepository.findById(any()))
+                .thenReturn(Optional.of(user));
+
+        when(paymentRepository.findByPayerIdAndAuctionId(any(), any()))
+                .thenReturn(List.of(Payment.of(user, tossPaymentResponse, any(Auction.class))));
+        assertThrows(PaymentException.class, () -> paymentService.approval(1L, approvalRequest));
     }
 }

--- a/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,38 @@
+package org.chzz.market.domain.payment.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
+import org.chzz.market.domain.payment.entity.Payment;
+import org.chzz.market.domain.payment.entity.Status;
+import org.chzz.market.domain.payment.error.PaymentException;
+import org.chzz.market.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+
+    @Test
+    @DisplayName("완료된 결제의 경우 예외를 발생시킨다")
+    void assertThatValidateOrderIdWillFilterDone() {
+        TossPaymentResponse tossPaymentResponse = new TossPaymentResponse();
+        tossPaymentResponse.setStatus(Status.DONE);
+        when(paymentRepository.findByPayerIdAndAuctionId(any(),any()))
+                .thenReturn(List.of(Payment.of(any(), tossPaymentResponse,any())));
+        assertThrows(PaymentException.class, () -> paymentService.validateDuplicatePayment(0L, 0L));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-166]

## 📝작업 내용


- 결제 승인시 점검 조건을 `DONE` 상태의 결제가 있는경우가 아닌 없는경우로 변경

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->

- ![image](https://github.com/user-attachments/assets/99802fb7-5fab-4791-9306-bb0ab03b74a4)



[CHZZ-166]: https://chzz-market.atlassian.net/browse/CHZZ-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ