### PR TITLE
fix: jwt 토큰 재발행시 동시성 문제 해결 및 분산락 적용

### DIFF
--- a/.github/workflows/deployment-config.yml
+++ b/.github/workflows/deployment-config.yml
@@ -64,17 +64,7 @@ jobs:
       # 테스트 실행
       - name: Test with Gradle
         run: |
-          ./gradlew -Dspring.profiles.active=test \
-          -Dcloud.aws.credentials.access-key=${{ secrets.S3_AWS_ACCESS_KEY_ID }} \
-          -Dcloud.aws.credentials.secret-key=${{ secrets.S3_AWS_SECRET_ACCESS_KEY }} \
-          -Dcloud.aws.region.static=${{ secrets.AWS_REGION }} \
-          -Dcloud.aws.s3.bucket=${{ secrets.AWS_S3_BUCKET }} \
-          -Dcloud.aws.cloudfront.domain=${{ secrets.AWS_CLOUDFRONT_DOMAIN }} \
-          -Dpayment.toss.client-key=${{ secrets.TEST_CLIENT_KEY }} \
-          -Dpayment.toss.security-key=${{ secrets.TEST_SECRET_KEY }} \
-          -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
-          -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
-          test
+          ./gradlew -Dspring.profiles.active=test test
 
       # 버전 추출
       - name: Extract version from PR branch name

--- a/.github/workflows/intergration-config.yml
+++ b/.github/workflows/intergration-config.yml
@@ -50,13 +50,6 @@ jobs:
       - name: Test with Gradle
         run: |
           ./gradlew -Dspring.profiles.active=test \
-          -Dcloud.aws.credentials.access-key=${{ secrets.S3_AWS_ACCESS_KEY_ID }} \
-          -Dcloud.aws.credentials.secret-key=${{ secrets.S3_AWS_SECRET_ACCESS_KEY }} \
-          -Dcloud.aws.region.static=${{ secrets.AWS_REGION }} \
-          -Dcloud.aws.s3.bucket=${{ secrets.AWS_S3_BUCKET }} \
-          -Dcloud.aws.cloudfront.domain=${{ secrets.AWS_CLOUDFRONT_DOMAIN }} \
-          -Dpayment.toss.client-key=${{ secrets.TEST_CLIENT_KEY }} \
-          -Dpayment.toss.security-key=${{ secrets.TEST_SECRET_KEY }} \
           -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
           -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
           test

--- a/.github/workflows/intergration-config.yml
+++ b/.github/workflows/intergration-config.yml
@@ -49,7 +49,4 @@ jobs:
       # 테스트 실행
       - name: Test with Gradle
         run: |
-          ./gradlew -Dspring.profiles.active=test \
-          -Dspring.data.redis.host=${{ secrets.TEST_REDIS_HOST }} \
-          -Dspring.data.redis.port=${{ secrets.TEST_REDIS_PORT }} \
-          test
+          ./gradlew -Dspring.profiles.active=test test

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.37.0'
+
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/src/main/java/org/chzz/market/common/aop/redisrock/AopForTransaction.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/AopForTransaction.java
@@ -1,0 +1,18 @@
+package org.chzz.market.common.aop.redisrock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/org/chzz/market/common/aop/redisrock/CustomSpringELParser.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/CustomSpringELParser.java
@@ -1,0 +1,24 @@
+package org.chzz.market.common.aop.redisrock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Spring Expression Language Parser
+ */
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLock.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLock.java
@@ -1,0 +1,43 @@
+package org.chzz.market.common.aop.redisrock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redisson 분산 락을 적용하는 어노테이션
+ * 사용 예시:
+ * (1) 단일 파라미터를 사용하여 락의 이름을 지정하는 경우
+ * @DistributedLock(key = "#lockName")
+ * public void shipment(String lockName) { // ... }
+ *
+ * (2) 복합 키를 사용하여 락의 이름을 지정하는 경우
+ * @DistributedLock(key = "#model.getName().concat('-').concat(#model.getShipmentOrderNumber())")
+ * public void shipment(ShipmentModel model) { // ... }
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s) 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s) 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
+++ b/src/main/java/org/chzz/market/common/aop/redisrock/DistributedLockAop.java
@@ -1,0 +1,54 @@
+package org.chzz.market.common.aop.redisrock;
+
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(org.chzz.market.common.aop.redisrock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(),
+                joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);  // (1) 락의 이름으로 RLock 인스턴스를 가져옴
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(),
+                    distributedLock.timeUnit());  // (2) 정의된 waitTime까지 획득을 시도, 정의된 leaseTime이 지나면 잠금을 해제
+            if (!available) {
+                return false;
+            }
+            return aopForTransaction.proceed(joinPoint);  // (3) DistributedLock 어노테이션이 선언된 메서드를 별도의 트랜잭션으로 실행
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();   // (4) 종료 시 무조건 락을 해제
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock already unlocked: serviceName={}, key={}", method.getName(), key);
+            }
+        }
+    }
+}

--- a/src/main/java/org/chzz/market/common/config/AWSConfig.java
+++ b/src/main/java/org/chzz/market/common/config/AWSConfig.java
@@ -7,10 +7,8 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile({"local", "prod"})
 public class AWSConfig {
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
@@ -21,9 +19,6 @@ public class AWSConfig {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
     @Bean
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
@@ -32,9 +27,4 @@ public class AWSConfig {
                 .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
     }
-
-    public String s3BucketName() {
-        return bucket;
-    }
-
 }

--- a/src/main/java/org/chzz/market/common/config/RedisConfig.java
+++ b/src/main/java/org/chzz/market/common/config/RedisConfig.java
@@ -16,6 +16,9 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+/**
+ * 기본적인 데이터 저장 및 Pub/Sub
+ */
 @Configuration
 @EnableAutoConfiguration(exclude = RedisAutoConfiguration.class)
 public class RedisConfig {

--- a/src/main/java/org/chzz/market/common/config/RedissonConfig.java
+++ b/src/main/java/org/chzz/market/common/config/RedissonConfig.java
@@ -1,0 +1,31 @@
+package org.chzz.market.common.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 분산락을 관리하는 용도
+ */
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/src/main/java/org/chzz/market/common/dto/ApiEndpoint.java
+++ b/src/main/java/org/chzz/market/common/dto/ApiEndpoint.java
@@ -1,0 +1,10 @@
+package org.chzz.market.common.dto;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpMethod;
+
+public record ApiEndpoint(String url, HttpMethod method) {
+    public boolean matches(HttpServletRequest request) {
+        return request.getRequestURI().equals(url) && request.getMethod().equals(method.name());
+    }
+}

--- a/src/main/java/org/chzz/market/common/error/GlobalErrorCode.java
+++ b/src/main/java/org/chzz/market/common/error/GlobalErrorCode.java
@@ -11,6 +11,7 @@ public enum GlobalErrorCode implements ErrorCode {
     UNSUPPORTED_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "Unsupported type of parameter included"),
     UNSUPPORTED_PARAMETER_NAME(HttpStatus.BAD_REQUEST, "Unsupported productName of parameter included"),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "Validation failed"),
+    COOKIE_NOT_FOUND(HttpStatus.BAD_REQUEST, "Required cookie is not found"),
     AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "Authentication is required"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access is denied"),
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "Unsupported type of sort"),

--- a/src/main/java/org/chzz/market/common/util/CookieUtil.java
+++ b/src/main/java/org/chzz/market/common/util/CookieUtil.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Base64;
+import org.chzz.market.common.error.GlobalErrorCode;
+import org.chzz.market.common.error.GlobalException;
 import org.chzz.market.domain.token.entity.TokenType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
@@ -38,6 +40,14 @@ public class CookieUtil {
             }
         }
         return null;
+    }
+
+    public static String getCookieByNameOrThrow(HttpServletRequest request, String cookieName) {
+        Cookie cookie = getCookieByName(request, cookieName);
+        if (cookie != null) {
+            return cookie.getValue();
+        }
+        throw new GlobalException(GlobalErrorCode.COOKIE_NOT_FOUND);
     }
 
     public static void expireCookie(HttpServletResponse response, String cookieName) {

--- a/src/main/java/org/chzz/market/domain/notification/entity/NotificationType.java
+++ b/src/main/java/org/chzz/market/domain/notification/entity/NotificationType.java
@@ -24,7 +24,7 @@ public enum NotificationType {
             return new AuctionWinnerNotification(user, event.image(), event.message(), event.getAuctionId());
         }
     },
-    AUCTION_NON_WINNER("안타깝지만 입찰에 참여한 %s 경매에 낙찰되지 못했습니다.", Values.AUCTION_NON_WINNER) {
+    AUCTION_NON_WINNER("입찰에 참여한 %s 경매에 낙찰되지 못했습니다.", Values.AUCTION_NON_WINNER) {
         @Override
         public Notification createNotification(User user, NotificationEvent event) {
             return new AuctionNonWinnerNotification(user, event.image(), event.message());

--- a/src/main/java/org/chzz/market/domain/user/controller/UserController.java
+++ b/src/main/java/org/chzz/market/domain/user/controller/UserController.java
@@ -115,8 +115,8 @@ public class UserController implements UserApi {
     @Override
     @PostMapping("/tokens/reissue")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
-        Cookie refreshCookie = CookieUtil.getCookieByName(request, TokenType.REFRESH.name());
-        Map<TokenType, String> newTokens = tokenService.reissue(refreshCookie);
+        String refreshToken = CookieUtil.getCookieByNameOrThrow(request, TokenType.REFRESH.name());
+        Map<TokenType, String> newTokens = tokenService.reissue(refreshToken);
         // 새로운 리프레쉬 토큰 발급
         CookieUtil.createTokenCookie(response, newTokens.get(TokenType.REFRESH), TokenType.REFRESH);
         // 새로운 엑세스 토큰 발급
@@ -130,8 +130,8 @@ public class UserController implements UserApi {
     @Override
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        Cookie refreshCookie = CookieUtil.getCookieByName(request, TokenType.REFRESH.name());
-        tokenService.logout(refreshCookie);
+        String refreshToken = CookieUtil.getCookieByNameOrThrow(request, TokenType.REFRESH.name());
+        tokenService.logout(refreshToken);
         CookieUtil.expireCookie(response, TokenType.REFRESH.name());
         return ResponseEntity.ok().build();
     }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,8 +18,8 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: localhost
+      port: 6379
       repositories:
         enabled: false
 

--- a/src/test/java/org/chzz/market/MarketApplicationTests.java
+++ b/src/test/java/org/chzz/market/MarketApplicationTests.java
@@ -1,16 +1,13 @@
 package org.chzz.market;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
-@MockBean(AmazonS3.class)
 class MarketApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/org/chzz/market/common/AWSConfig.java
+++ b/src/test/java/org/chzz/market/common/AWSConfig.java
@@ -20,10 +20,4 @@ public class AWSConfig {
     public AWSCredentialsProvider awsCredentialsProvider() {
         return Mockito.mock(AWSCredentialsProvider.class);
     }
-
-    @Bean
-    @Primary
-    public String s3BucketName() {
-        return "test-bucket";
-    }
 }

--- a/src/test/java/org/chzz/market/domain/token/service/TokenServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/token/service/TokenServiceTest.java
@@ -95,7 +95,7 @@ class TokenServiceTest {
                 Optional.of(new TokenData("refresh-token", user.getId())));
 
         // when
-        tokenService.logout(refreshCookie);
+        tokenService.logout(refreshCookie.getValue());
 
         // then
         verify(jwtUtil, times(1)).validateToken("refresh-token", TokenType.REFRESH);
@@ -110,7 +110,7 @@ class TokenServiceTest {
         when(refreshTokenRepository.findByToken("refresh-token")).thenReturn(Optional.empty());
 
         // when & then
-        TokenException exception = assertThrows(TokenException.class, () -> tokenService.reissue(refreshCookie));
+        TokenException exception = assertThrows(TokenException.class, () -> tokenService.reissue(refreshCookie.getValue()));
         assertThat(exception.getErrorCode()).isEqualTo(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
     }
 
@@ -122,7 +122,7 @@ class TokenServiceTest {
         when(refreshTokenRepository.findByToken("refresh-token")).thenReturn(Optional.empty());
 
         // when & then
-        TokenException exception = assertThrows(TokenException.class, () -> tokenService.logout(refreshCookie));
+        TokenException exception = assertThrows(TokenException.class, () -> tokenService.logout(refreshCookie.getValue()));
         assertThat(exception.getErrorCode()).isEqualTo(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-175]

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 리프레쉬토큰으로 재발행 시 동시성 오류가 발생해서 분산락 적용으로 해결하였습니다.
- 같은 리프레쉬토큰으로 여러개의 재발행 요청이 오면 하나의 재발행만 성공 후 나머지는 예외가 던져지게 됩니다.
- 기존 기본적인 데이터 저장 및 Pub/Sub으로 Redis  Lettece를 사용했지만, 분산락은 Redisson 을 사용하였습니다.
  - 분산 락의 간편한 구현, 복잡한 동시성 문제 해결에 특화 등의 장점인 이유입니다.
- 커스텀 어노테이션을 추가하였습니다.

아래의 링크를 참고하였습니다.
[풀필먼트 입고 서비스팀에서 분산락을 사용하는 방법 - Spring Redisson](https://helloworld.kurly.com/blog/distributed-redisson-lock/)
## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->
- 초기 홈 화면 호출

![스크린샷 2024-10-27 오전 1 42 16](https://github.com/user-attachments/assets/9f6b0c30-77a0-4d09-8371-31837c47eea6)

- 만료된 토큰으로 새로고침 (하나의 재발행만 성공)
![스크린샷 2024-10-27 오전 1 43 03](https://github.com/user-attachments/assets/d79bd43b-f215-4261-8dbc-d1497eaf4875)

![스크린샷 2024-10-27 오전 1 43 37](https://github.com/user-attachments/assets/59e8b96b-8841-454d-ade4-d661b2276cb4)


## 🙏리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- 만약 없다면 이 부분을 삭제해주세요 -->

- 이 부분은 프론트에서 하나의 재발행 요청으로 묶어 호출하는 것으로 해결하였지만, 이는 서버에서도 막아야된다고 생각해 처리하였습니다.


[CHZZ-175]: https://chzz-market.atlassian.net/browse/CHZZ-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ