### PR TITLE
refactor: 금액 범위 수정

### DIFF
--- a/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
@@ -4,9 +4,8 @@ import static org.chzz.market.domain.product.entity.Product.Category;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -44,8 +43,7 @@ public abstract class BaseRegisterRequest {
 
     @NotNull
     @ThousandMultiple
-    @Min(value = 1000, message = "시작 가격은 최소 1,000원 이상, 1000의 배수이어야 합니다")
-    @Max(value = 2_000_000,message = "최소금액은 200만원을 넘을 수 없습니다")
+    @Max(value = 2_000_000, message = "최소금액은 200만원을 넘을 수 없습니다")
     protected Integer minPrice;
 
     @NotNull(message = "경매 타입을 선택해주세요")

--- a/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
+++ b/src/main/java/org/chzz/market/domain/auction/dto/request/BaseRegisterRequest.java
@@ -4,6 +4,8 @@ import static org.chzz.market.domain.product.entity.Product.Category;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -38,6 +40,8 @@ public abstract class BaseRegisterRequest {
 
     @NotNull
     @ThousandMultiple
+    @Min(value = 1000, message = "시작 가격은 최소 1,000원 이상, 1000의 배수이어야 합니다")
+    @Max(value = 2_000_000,message = "최소금액은 200만원을 넘을 수 없습니다")
     protected Integer minPrice;
 
     @NotNull(message = "경매 타입을 선택해주세요")

--- a/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
+++ b/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
@@ -1,5 +1,7 @@
 package org.chzz.market.domain.bid.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +21,8 @@ public class BidCreateRequest {
     private Long auctionId;
 
     @ThousandMultiple(message = "1,000원 단위로 입력해주세요.")
+    @Min(value = 1000, message = "입찰금은 최소 1,000원 이상, 1000의 배수이어야 합니다")
+    @Max(value = 2_000_000,message = "입찰금액은 200만원을 넘을 수 없습니다")
     private Long bidAmount;
 
     public Bid toEntity(Auction auction, User user) {

--- a/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
+++ b/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.common.validation.annotation.ThousandMultiple;
 import org.chzz.market.domain.auction.entity.Auction;
@@ -12,6 +13,7 @@ import org.chzz.market.domain.user.entity.User;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 @Builder
 public class BidCreateRequest {
     @NotNull

--- a/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
+++ b/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
@@ -28,12 +28,4 @@ public class BidCreateRequest {
                 .amount(bidAmount)
                 .build();
     }
-
-    public @NotNull Long getAuctionId() {
-        return this.auctionId;
-    }
-
-    public @Max(value = 2_000_000, message = "입찰금액은 200만원을 넘을 수 없습니다") Long getBidAmount() {
-        return this.bidAmount;
-    }
 }

--- a/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
+++ b/src/main/java/org/chzz/market/domain/bid/dto/BidCreateRequest.java
@@ -1,18 +1,15 @@
 package org.chzz.market.domain.bid.dto;
 
 import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.chzz.market.common.validation.annotation.ThousandMultiple;
 import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.bid.entity.Bid;
 import org.chzz.market.domain.user.entity.User;
 
-@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -21,8 +18,7 @@ public class BidCreateRequest {
     private Long auctionId;
 
     @ThousandMultiple(message = "1,000원 단위로 입력해주세요.")
-    @Min(value = 1000, message = "입찰금은 최소 1,000원 이상, 1000의 배수이어야 합니다")
-    @Max(value = 2_000_000,message = "입찰금액은 200만원을 넘을 수 없습니다")
+    @Max(value = 2_000_000, message = "입찰금액은 200만원을 넘을 수 없습니다")
     private Long bidAmount;
 
     public Bid toEntity(Auction auction, User user) {
@@ -31,5 +27,13 @@ public class BidCreateRequest {
                 .bidder(user)
                 .amount(bidAmount)
                 .build();
+    }
+
+    public @NotNull Long getAuctionId() {
+        return this.auctionId;
+    }
+
+    public @Max(value = 2_000_000, message = "입찰금액은 200만원을 넘을 수 없습니다") Long getBidAmount() {
+        return this.bidAmount;
     }
 }

--- a/src/main/java/org/chzz/market/domain/order/service/OrderService.java
+++ b/src/main/java/org/chzz/market/domain/order/service/OrderService.java
@@ -7,7 +7,7 @@ import org.chzz.market.domain.address.exception.AddressException;
 import org.chzz.market.domain.address.repository.AddressRepository;
 import org.chzz.market.domain.order.entity.Order;
 import org.chzz.market.domain.order.repository.OrderRepository;
-import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
+import org.chzz.market.domain.payment.dto.request.ShippingAddressRequest;
 import org.chzz.market.domain.payment.dto.SuccessfulPaymentEvent;
 import org.chzz.market.domain.payment.entity.Payment;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/org/chzz/market/domain/payment/dto/SuccessfulPaymentEvent.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/SuccessfulPaymentEvent.java
@@ -1,5 +1,6 @@
 package org.chzz.market.domain.payment.dto;
 
+import org.chzz.market.domain.payment.dto.request.ShippingAddressRequest;
 import org.chzz.market.domain.payment.entity.Payment;
 
 public record SuccessfulPaymentEvent(Long userId, Payment payment, ShippingAddressRequest shippingAddressRequest) {

--- a/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
@@ -1,9 +1,12 @@
 package org.chzz.market.domain.payment.dto.request;
 
-import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 public record ApprovalRequest(String orderId,
                               String paymentKey,
+                              @Min(value = 1000, message = "결제금액은 최소 1,000원 이상, 1000의 배수이어야 합니다")
+                              @Max(value = 2_000_000,message = "결제금액은 200만원을 넘을 수 없습니다")
                               Long amount,
                               Long auctionId,
                               ShippingAddressRequest shippingAddressRequest) {

--- a/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
@@ -6,7 +6,7 @@ import org.chzz.market.common.validation.annotation.ThousandMultiple;
 public record ApprovalRequest(String orderId,
                               String paymentKey,
                               @ThousandMultiple
-                              @Max(value = 2_000_000,message = "결제금액은 200만원을 넘을 수 없습니다")
+                              @Max(value = 2_000_000, message = "결제금액은 200만원을 넘을 수 없습니다")
                               Long amount,
                               Long auctionId,
                               ShippingAddressRequest shippingAddressRequest) {

--- a/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/request/ApprovalRequest.java
@@ -1,11 +1,11 @@
 package org.chzz.market.domain.payment.dto.request;
 
 import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import org.chzz.market.common.validation.annotation.ThousandMultiple;
 
 public record ApprovalRequest(String orderId,
                               String paymentKey,
-                              @Min(value = 1000, message = "결제금액은 최소 1,000원 이상, 1000의 배수이어야 합니다")
+                              @ThousandMultiple
                               @Max(value = 2_000_000,message = "결제금액은 200만원을 넘을 수 없습니다")
                               Long amount,
                               Long auctionId,

--- a/src/main/java/org/chzz/market/domain/payment/dto/request/ShippingAddressRequest.java
+++ b/src/main/java/org/chzz/market/domain/payment/dto/request/ShippingAddressRequest.java
@@ -1,4 +1,4 @@
-package org.chzz.market.domain.payment.dto;
+package org.chzz.market.domain.payment.dto.request;
 
 import jakarta.annotation.Nullable;
 

--- a/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
+++ b/src/main/java/org/chzz/market/domain/payment/service/PaymentService.java
@@ -7,7 +7,7 @@ import org.chzz.market.domain.auction.entity.Auction;
 import org.chzz.market.domain.auction.error.AuctionErrorCode;
 import org.chzz.market.domain.auction.error.AuctionException;
 import org.chzz.market.domain.auction.repository.AuctionRepository;
-import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
+import org.chzz.market.domain.payment.dto.request.ShippingAddressRequest;
 import org.chzz.market.domain.payment.dto.SuccessfulPaymentEvent;
 import org.chzz.market.domain.payment.dto.request.ApprovalRequest;
 import org.chzz.market.domain.payment.dto.response.ApprovalResponse;

--- a/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
@@ -2,6 +2,7 @@ package org.chzz.market.domain.product.dto;
 
 import static org.chzz.market.domain.product.entity.Product.Category;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -28,6 +29,7 @@ public class UpdateProductRequest {
 
     @ThousandMultiple
     @Min(value = 1000, message = "시작 가격은 최소 1,000원 이상, 1000의 배수이어야 합니다")
+    @Max(value = 2_000_000,message = "최소금액은 200만원을 넘을 수 없습니다")
     private Integer minPrice;
 
     @Builder.Default

--- a/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
+++ b/src/main/java/org/chzz/market/domain/product/dto/UpdateProductRequest.java
@@ -2,9 +2,9 @@ package org.chzz.market.domain.product.dto;
 
 import static org.chzz.market.domain.auction.dto.request.BaseRegisterRequest.DESCRIPTION_REGEX;
 import static org.chzz.market.domain.product.entity.Product.Category;
-import jakarta.validation.constraints.Max;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.HashMap;
@@ -31,8 +31,7 @@ public class UpdateProductRequest {
     private Category category;
 
     @ThousandMultiple
-    @Min(value = 1000, message = "시작 가격은 최소 1,000원 이상, 1000의 배수이어야 합니다")
-    @Max(value = 2_000_000,message = "최소금액은 200만원을 넘을 수 없습니다")
+    @Max(value = 2_000_000, message = "최소금액은 200만원을 넘을 수 없습니다")
     private Integer minPrice;
 
     @Builder.Default

--- a/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/org/chzz/market/domain/payment/service/PaymentServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import org.chzz.market.domain.auction.entity.Auction;
-import org.chzz.market.domain.payment.dto.ShippingAddressRequest;
+import org.chzz.market.domain.payment.dto.request.ShippingAddressRequest;
 import org.chzz.market.domain.payment.dto.request.ApprovalRequest;
 import org.chzz.market.domain.payment.dto.response.TossPaymentResponse;
 import org.chzz.market.domain.payment.entity.Payment;


### PR DESCRIPTION
## #️⃣연관된 이슈

[CHZZ-176]

## 📝작업 내용


- 입찰, 경매 등록 등 금액 입력이 가능한 요청들의 금액 범위를 토스 단일 최대 결제가능 금액 한도인 200만원으로 지정

## ✅테스트 결과

<!-- 테스트 결과 또는 결과물에 대한 스크린샷, 라이브 데모를 위한 샘플 API 등을 첨부해주세요 -->



[CHZZ-176]: https://chzz-market.atlassian.net/browse/CHZZ-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ